### PR TITLE
도서 상세 조회 API 연동

### DIFF
--- a/src/apis/book.ts
+++ b/src/apis/book.ts
@@ -1,6 +1,10 @@
 import axios from 'axios';
 
-import type { GetBooksQueryModel, GetBooksServerModel } from '@/types';
+import type {
+  GetBookDetailQueryModel,
+  GetBooksQueryModel,
+  GetBooksServerModel,
+} from '@/types';
 
 const Kakao = axios.create({
   baseURL: 'https://dapi.kakao.com',
@@ -13,6 +17,15 @@ export const getBooksAPI = async (req: GetBooksQueryModel) => {
   const { data } = await Kakao.get<GetBooksServerModel>('/v3/search/book', {
     params: req,
   });
+
+  return data;
+};
+
+export const getBookDetailAPI = async (req: GetBookDetailQueryModel) => {
+  const { data } = await Kakao.get<GetBooksServerModel>(
+    '/v3/search/book?sort=accuracy&page=1&size=10&target=isbn',
+    { params: req },
+  );
 
   return data;
 };

--- a/src/components/composites/book/detail/BookDetail.tsx
+++ b/src/components/composites/book/detail/BookDetail.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 
-import type { GetBookRecordsServerModel, GetBooksServerModel } from '@/types';
+import { useGetBookDetail } from '@/services';
+import type { GetBookRecordsServerModel } from '@/types';
 import BookInfoContent from './Info/BookDetailInfo';
 import BookRecordList from './record/BookRecordList';
 
 const BookDetail = () => {
+  const { id: isbn } = useParams();
+
+  const query = isbn ? isbn.split(' ').filter((item) => item)[0] : '';
+  const req = { query };
+  const { data } = useGetBookDetail(req);
+
   const bookRecordServerData: GetBookRecordsServerModel = {
     pageInfo: {
       totalCount: 37,
@@ -74,35 +82,11 @@ const BookDetail = () => {
     ],
   };
 
-  const bookServerData: GetBooksServerModel = {
-    meta: {
-      is_end: true,
-      pageable_count: 9,
-      total_count: 10,
-    },
-    documents: [
-      {
-        authors: ['기시미 이치로', '고가 후미타케'],
-        contents:
-          '인간은 변할 수 있고, 누구나 행복해 질 수 있다. 단 그러기 위해서는 ‘용기’가 필요하다고 말한 철학자가 있다. 바로 프로이트, 융과 함께 ‘심리학의 3대 거장’으로 일컬어지고 있는 알프레드 아들러다. 『미움받을 용기』는 아들러 심리학에 관한 일본의 1인자 철학자 기시미 이치로와 베스트셀러 작가인 고가 후미타케의 저서로, 아들러의 심리학을 ‘대화체’로 쉽고 맛깔나게 정리하고 있다. 아들러 심리학을 공부한 철학자와 세상에 부정적이고 열등감 많은',
-        datetime: '2014-11-17T00:00:00.000+09:00',
-        isbn: '8996991341 9788996991342',
-        price: 14900,
-        publisher: '인플루엔셜',
-        sale_price: 13410,
-        status: '정상판매',
-        thumbnail:
-          'https://search1.kakaocdn.net/thumb/R120x174.q85/?fname=http%3A%2F%2Ft1.daumcdn.net%2Flbook%2Fimage%2F1467038',
-        title: '미움받을 용기',
-        translators: ['전경아'],
-        url: 'https://search.daum.net/search?w=bookpage&bookId=1467038&q=%EB%AF%B8%EC%9B%80%EB%B0%9B%EC%9D%84+%EC%9A%A9%EA%B8%B0',
-      },
-    ],
-  };
+  if (!data) return null;
 
   return (
     <>
-      <BookInfoContent book={bookServerData.documents[0]} />
+      <BookInfoContent book={data.documents[0]} />
       <BookRecordList bookRecordData={bookRecordServerData} />
     </>
   );

--- a/src/components/composites/book/detail/Info/BookDetailInfo.skeleton.tsx
+++ b/src/components/composites/book/detail/Info/BookDetailInfo.skeleton.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import Skeleton from 'react-loading-skeleton';
+
+import * as S from './BookDetailInfo.styled';
+
+const BookDetailInfoSkeleton = () => {
+  return (
+    <S.BookDetailSection>
+      <S.BookThumbnailSection src="">
+        <Skeleton css={S.bookThumbnail} />
+      </S.BookThumbnailSection>
+      <S.BookInfoWrapper>
+        <S.BookSubInfoList>
+          <S.BookSubInfoWrapper>
+            <S.BookSubInfoTitle>평점</S.BookSubInfoTitle>
+            <S.BookSubInfoDescription>
+              <Skeleton width={50} />
+            </S.BookSubInfoDescription>
+          </S.BookSubInfoWrapper>
+          <S.BookSubInfoWrapper>
+            <S.BookSubInfoTitle>읽기 완료 수</S.BookSubInfoTitle>
+            <S.BookSubInfoDescription>
+              <Skeleton width={50} />
+            </S.BookSubInfoDescription>
+          </S.BookSubInfoWrapper>
+          <S.BookSubInfoWrapper>
+            <S.BookSubInfoTitle>읽기 상태</S.BookSubInfoTitle>
+            <S.BookSubInfoDescription>
+              <Skeleton width={50} />
+            </S.BookSubInfoDescription>
+          </S.BookSubInfoWrapper>
+        </S.BookSubInfoList>
+        <S.BookInfoList>
+          <S.BookInfoTitle>책 제목</S.BookInfoTitle>
+          <S.BookInfoDescription>
+            <Skeleton width={100} />
+          </S.BookInfoDescription>
+          <S.BookInfoTitle>출간날짜</S.BookInfoTitle>
+          <S.BookInfoDescription>
+            <Skeleton width={100} />
+          </S.BookInfoDescription>
+          <S.BookInfoTitle>ISBN</S.BookInfoTitle>
+          <S.BookInfoDescription>
+            <Skeleton width={100} />
+          </S.BookInfoDescription>
+          <S.BookInfoTitle>저자</S.BookInfoTitle>
+          <S.BookInfoDescription>
+            <Skeleton width={100} />
+          </S.BookInfoDescription>
+          <S.BookInfoTitle>번역자</S.BookInfoTitle>
+          <S.BookInfoDescription>
+            <Skeleton width={100} />
+          </S.BookInfoDescription>
+          <S.BookInfoTitle>출판사</S.BookInfoTitle>
+          <S.BookInfoDescription>
+            <Skeleton width={100} />
+          </S.BookInfoDescription>
+          <S.BookInfoTitle>상세 내용</S.BookInfoTitle>
+          <S.BookInfoDescription>
+            <Skeleton width="100%" height={62.36} />
+          </S.BookInfoDescription>
+        </S.BookInfoList>
+      </S.BookInfoWrapper>
+    </S.BookDetailSection>
+  );
+};
+
+export default BookDetailInfoSkeleton;

--- a/src/components/composites/book/detail/Info/BookDetailInfo.styled.ts
+++ b/src/components/composites/book/detail/Info/BookDetailInfo.styled.ts
@@ -36,7 +36,13 @@ export const BookThumbnailSection = styled.section<{ src: string }>`
   `}
 `;
 
-export const BookThumbnail = tw.img`relative w-[144px] h-[216px] rounded-[4px] object-fill shadow-light_lg tablet:(w-[178px] h-[252px]) desktop:(w-[198px] h-[286px])`;
+export const bookThumbnail = css`
+  ${tw`relative w-[144px] h-[216px] rounded-[4px] object-fill shadow-light_lg tablet:(w-[178px] h-[252px]) desktop:(w-[198px] h-[286px])`}
+`;
+
+export const BookThumbnail = styled.img`
+  ${bookThumbnail};
+`;
 
 export const BookInfoList = tw.dl`grid grid-cols-[minmax(80px, auto) 1fr] gap-y-[4px] rounded-[4px] px-[12px] py-[10px] bg-brown50 tablet:mx-auto`;
 

--- a/src/components/composites/book/detail/Info/BookDetailInfo.tsx
+++ b/src/components/composites/book/detail/Info/BookDetailInfo.tsx
@@ -62,7 +62,7 @@ const BookDetailInfo = ({ book }: BookInfoContentProps) => {
           </S.BookInfoDescription>
           <S.BookInfoTitle>번역자</S.BookInfoTitle>
           <S.BookInfoDescription>
-            {book.translators.join(', ')}
+            {book.translators.join(', ') || '-'}
           </S.BookInfoDescription>
           <S.BookInfoTitle>출판사</S.BookInfoTitle>
           <S.BookInfoDescription>{book.publisher}</S.BookInfoDescription>

--- a/src/components/composites/book/detail/Info/index.ts
+++ b/src/components/composites/book/detail/Info/index.ts
@@ -1,0 +1,2 @@
+export { default as BookDetailInfo } from './BookDetailInfo';
+export { default as BookDetailInfoSkeleton } from './BookDetailInfo.skeleton';

--- a/src/components/composites/book/detail/index.ts
+++ b/src/components/composites/book/detail/index.ts
@@ -1,0 +1,2 @@
+export * from './Info';
+export { default as BookDetail } from './BookDetail';

--- a/src/components/composites/book/index.ts
+++ b/src/components/composites/book/index.ts
@@ -1,3 +1,3 @@
+export * from './detail';
 export * from './list';
-export { default as BookDetail } from './detail/BookDetail';
 export { default as BookSearch } from './search/BookSearch';

--- a/src/components/composites/book/list/data/BookListData.tsx
+++ b/src/components/composites/book/list/data/BookListData.tsx
@@ -12,8 +12,8 @@ const BookListData = ({ books }: BookListDataProps) => {
     books.map((book) => (
       <BookListCard
         key={book.isbn}
-        readingStatus={book.readingStatus}
-        rating={book.rating}
+        readingStatus="pending" // TODO: 수정 예정
+        rating={4.5} // TODO: 수정 예정
         isbn={book.isbn}
         thumbnail={book.thumbnail}
         bookTitle={book.title}

--- a/src/pages/book/[id]/index.tsx
+++ b/src/pages/book/[id]/index.tsx
@@ -1,12 +1,11 @@
 import React, { Suspense } from 'react';
 
-import { BookDetail, MainLayout } from '@/components';
+import { BookDetail, BookDetailInfoSkeleton, MainLayout } from '@/components';
 
 const root = () => {
   return (
     <MainLayout>
-      {/* TODO: 스켈레톤 UI 추가 예정 */}
-      <Suspense fallback={<></>}>
+      <Suspense fallback={<BookDetailInfoSkeleton />}>
         <BookDetail />
       </Suspense>
     </MainLayout>

--- a/src/pages/book/[id]/index.tsx
+++ b/src/pages/book/[id]/index.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 
 import { BookDetail, MainLayout } from '@/components';
 
 const root = () => {
   return (
     <MainLayout>
-      <BookDetail />
+      {/* TODO: 스켈레톤 UI 추가 예정 */}
+      <Suspense fallback={<></>}>
+        <BookDetail />
+      </Suspense>
     </MainLayout>
   );
 };

--- a/src/services/book.ts
+++ b/src/services/book.ts
@@ -1,17 +1,27 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 
-import { getBooksAPI } from '@/apis';
-import type { GetBooksQueryModel } from '@/types';
+import { getBookDetailAPI, getBooksAPI } from '@/apis';
+import type { GetBookDetailQueryModel, GetBooksQueryModel } from '@/types';
 
 const bookKeys = {
   all: ['book'] as const,
   lists: () => [...bookKeys.all, 'list'] as const,
   list: (req: GetBooksQueryModel) => [...bookKeys.lists(), req] as const,
+  details: () => [...bookKeys.all, 'detail'] as const,
+  detail: (req: GetBookDetailQueryModel) =>
+    [...bookKeys.details(), req] as const,
 };
 
 export const useGetBooks = (req: GetBooksQueryModel) => {
   return useSuspenseQuery({
     queryKey: bookKeys.list(req),
     queryFn: () => (req.query ? getBooksAPI(req) : null),
+  });
+};
+
+export const useGetBookDetail = (req: GetBookDetailQueryModel) => {
+  return useSuspenseQuery({
+    queryKey: bookKeys.detail(req),
+    queryFn: () => (req.query ? getBookDetailAPI(req) : null),
   });
 };

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -34,6 +34,10 @@ export interface GetBooksQueryModel {
   target: 'title' | 'isbn' | 'publisher' | 'person';
 }
 
+export interface GetBookDetailQueryModel {
+  query: string;
+}
+
 export interface GetBooksServerModel {
   meta: {
     is_end: boolean;

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -45,8 +45,6 @@ export interface GetBooksServerModel {
     total_count: number;
   };
   documents: {
-    readingStatus: (typeof BOOK_READING_STATUS_OPTIONS)[number]['key'];
-    rating: number | null;
     authors: string[];
     contents: string;
     datetime: string;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature -> main

### 변경 사항
1. API 연동
   a. 도서 상세 조회 API 연동 (카카오 도서 검색 API 이용)

2. 스크린 수정
   a. 도서 상세 정보 조회 중일 때 Suspense 이용하여 Skeleton UI 노출
   b. 도서 상세 정보 `translators` 없을 경우 하이픈 표기
 
3. 기타 수정
   a. 도서 정보 조회 응답 데이터 타입 수정 (`readingStatus`, `rating` 제거)


### 참고 사항
