### PR TITLE
독서 기록 관련 API 연동

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib';
+import { DB_TABLE_NAME } from '@/constants';
 import type {
   CheckNicknameDuplicatedQueryModel,
   LoginQueryModel,
@@ -9,7 +10,7 @@ export const checkNicknameDuplicatedAPI = async (
   req: CheckNicknameDuplicatedQueryModel,
 ) => {
   const { data, error } = await supabase
-    .from('users')
+    .from(DB_TABLE_NAME.AUTH)
     .select('nickname')
     .eq('nickname', req.nickname);
 

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
 export * from './book';
+export * from './record';

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib';
+import { DB_TABLE_NAME } from '@/constants';
 import type {
   CreateBookRecordStateQueryModel,
   GetBookRecordQueryModel,
@@ -8,7 +9,7 @@ import type {
 
 export const getBookRecordAPI = async (req: GetBookRecordQueryModel) => {
   const { data, error } = await supabase
-    .from('book_record')
+    .from(DB_TABLE_NAME.BOOK_RECORD)
     .select(
       'created_at, updated_at, id, isbn, rating, reading_start_at, reading_end_at, record_comment',
     )
@@ -42,7 +43,7 @@ export const createBookRecordStateAPI = async (
   const value = createBookRecordPayload(req);
 
   const { data, error } = await supabase
-    .from('book_record')
+    .from(DB_TABLE_NAME.BOOK_RECORD)
     .insert(value)
     .select();
 
@@ -60,7 +61,7 @@ export const updateBookRecordStateAPI = async (
   const value = createBookRecordPayload(rest);
 
   const { data, error } = await supabase
-    .from('book_record')
+    .from(DB_TABLE_NAME.BOOK_RECORD)
     .update(value)
     .eq('id', recordId)
     .select();

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -24,20 +24,26 @@ export const getBookRecordAPI = async (req: GetBookRecordQueryModel) => {
   return data;
 };
 
+const createBookRecordPayload = (req: CreateBookRecordStateQueryModel) => {
+  return {
+    user_id: req.userId,
+    isbn: req.isbn,
+    rating: req.rating ?? null,
+    reading_start_at: req.readingStartDate ?? null,
+    reading_end_at: req.readingEndDate ?? null,
+    record_comment: req.recordComment ?? null,
+    bookmark: req.bookMark ?? null,
+  };
+};
+
 export const createBookRecordStateAPI = async (
   req: CreateBookRecordStateQueryModel,
 ) => {
+  const value = createBookRecordPayload(req);
+
   const { data, error } = await supabase
     .from('book_record')
-    .insert({
-      user_id: req.userId,
-      isbn: req.isbn,
-      rating: req.rating ?? null,
-      reading_start_at: req.readingStartDate ?? null,
-      reading_end_at: req.readingEndDate ?? null,
-      record_comment: req.recordComment ?? null,
-      bookmark: req.bookMark ?? null,
-    })
+    .insert(value)
     .select();
 
   if (error) {
@@ -50,18 +56,13 @@ export const createBookRecordStateAPI = async (
 export const updateBookRecordStateAPI = async (
   req: UpdateBookRecordStateQueryModel,
 ) => {
+  const { recordId, ...rest } = req;
+  const value = createBookRecordPayload(rest);
+
   const { data, error } = await supabase
     .from('book_record')
-    .update({
-      user_id: req.userId,
-      isbn: req.isbn,
-      rating: req.rating ?? null,
-      reading_start_at: req.readingStartDate ?? null,
-      reading_end_at: req.readingEndDate ?? null,
-      record_comment: req.recordComment ?? null,
-      bookmark: req.bookMark ?? null,
-    })
-    .eq('id', req.recordId)
+    .update(value)
+    .eq('id', recordId)
     .select();
 
   if (error) {

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -1,0 +1,28 @@
+import { supabase } from '@/lib';
+import type { UpdateBookRecordStateQueryModel } from '@/types';
+
+export const updateBookRecordState = async (
+  req: UpdateBookRecordStateQueryModel,
+) => {
+  const { data, error } = await supabase
+    .from('book_record')
+    .upsert(
+      {
+        user_id: req.userId,
+        isbn: req.isbn,
+        rating: req.rating ?? null,
+        reading_start_at: req.readingStartDate ?? null,
+        reading_end_at: req.readingEndDate ?? null,
+        record_comment: req.recordComment ?? null,
+        bookmark: req.bookMark ?? null,
+      },
+      { onConflict: 'isbn' },
+    )
+    .select();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data;
+};

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -1,10 +1,10 @@
 import { supabase } from '@/lib';
 import { DB_TABLE_NAME } from '@/constants';
 import type {
-  CreateBookRecordStateQueryModel,
+  CreateBookRecordQueryModel,
   GetBookRecordQueryModel,
   GetBookRecordServerModel,
-  UpdateBookRecordStateQueryModel,
+  UpdateBookRecordQueryModel,
 } from '@/types';
 
 export const getBookRecordAPI = async (req: GetBookRecordQueryModel) => {
@@ -25,7 +25,7 @@ export const getBookRecordAPI = async (req: GetBookRecordQueryModel) => {
   return data;
 };
 
-const createBookRecordPayload = (req: CreateBookRecordStateQueryModel) => {
+const createBookRecordPayload = (req: CreateBookRecordQueryModel) => {
   return {
     user_id: req.userId,
     isbn: req.isbn,
@@ -37,9 +37,7 @@ const createBookRecordPayload = (req: CreateBookRecordStateQueryModel) => {
   };
 };
 
-export const createBookRecordStateAPI = async (
-  req: CreateBookRecordStateQueryModel,
-) => {
+export const createBookRecordAPI = async (req: CreateBookRecordQueryModel) => {
   const value = createBookRecordPayload(req);
 
   const { data, error } = await supabase
@@ -54,9 +52,7 @@ export const createBookRecordStateAPI = async (
   return data;
 };
 
-export const updateBookRecordStateAPI = async (
-  req: UpdateBookRecordStateQueryModel,
-) => {
+export const updateBookRecordAPI = async (req: UpdateBookRecordQueryModel) => {
   const { recordId, ...rest } = req;
   const value = createBookRecordPayload(rest);
 

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -1,7 +1,29 @@
 import { supabase } from '@/lib';
-import type { UpdateBookRecordStateQueryModel } from '@/types';
+import type {
+  GetBookRecordQueryModel,
+  GetBookRecordServerModel,
+  UpdateBookRecordStateQueryModel,
+} from '@/types';
 
-export const updateBookRecordState = async (
+export const getBookRecordAPI = async (req: GetBookRecordQueryModel) => {
+  const { data, error } = await supabase
+    .from('book_record')
+    .select(
+      'created_at, updated_at, id, isbn, rating, reading_start_at, reading_end_at, record_comment',
+    )
+    .eq('user_id', req.userId)
+    .eq('isbn', req.isbn)
+    .limit(1)
+    .returns<GetBookRecordServerModel>();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data;
+};
+
+export const updateBookRecordStateAPI = async (
   req: UpdateBookRecordStateQueryModel,
 ) => {
   const { data, error } = await supabase

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -1,5 +1,6 @@
 import { supabase } from '@/lib';
 import type {
+  CreateBookRecordStateQueryModel,
   GetBookRecordQueryModel,
   GetBookRecordServerModel,
   UpdateBookRecordStateQueryModel,
@@ -23,23 +24,44 @@ export const getBookRecordAPI = async (req: GetBookRecordQueryModel) => {
   return data;
 };
 
+export const createBookRecordStateAPI = async (
+  req: CreateBookRecordStateQueryModel,
+) => {
+  const { data, error } = await supabase
+    .from('book_record')
+    .insert({
+      user_id: req.userId,
+      isbn: req.isbn,
+      rating: req.rating ?? null,
+      reading_start_at: req.readingStartDate ?? null,
+      reading_end_at: req.readingEndDate ?? null,
+      record_comment: req.recordComment ?? null,
+      bookmark: req.bookMark ?? null,
+    })
+    .select();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data;
+};
+
 export const updateBookRecordStateAPI = async (
   req: UpdateBookRecordStateQueryModel,
 ) => {
   const { data, error } = await supabase
     .from('book_record')
-    .upsert(
-      {
-        user_id: req.userId,
-        isbn: req.isbn,
-        rating: req.rating ?? null,
-        reading_start_at: req.readingStartDate ?? null,
-        reading_end_at: req.readingEndDate ?? null,
-        record_comment: req.recordComment ?? null,
-        bookmark: req.bookMark ?? null,
-      },
-      { onConflict: 'isbn' },
-    )
+    .update({
+      user_id: req.userId,
+      isbn: req.isbn,
+      rating: req.rating ?? null,
+      reading_start_at: req.readingStartDate ?? null,
+      reading_end_at: req.readingEndDate ?? null,
+      record_comment: req.recordComment ?? null,
+      bookmark: req.bookMark ?? null,
+    })
+    .eq('id', req.recordId)
     .select();
 
   if (error) {

--- a/src/components/atoms/datePicker/DatePicker.tsx
+++ b/src/components/atoms/datePicker/DatePicker.tsx
@@ -183,6 +183,7 @@ const Calendar = ({
 
 interface DatePickerProps {
   isDisabled?: boolean;
+  hasError?: boolean;
   selectedDate: dayjs.Dayjs | null;
   placeholder: string;
   selectDate: (date: dayjs.Dayjs) => void;
@@ -190,6 +191,7 @@ interface DatePickerProps {
 
 const DatePicker = ({
   isDisabled = false,
+  hasError = false,
   selectedDate,
   placeholder,
   selectDate,
@@ -207,6 +209,7 @@ const DatePicker = ({
       <Input
         css={S.datePickerInput}
         isDisabled={isDisabled}
+        hasError={hasError}
         isReadOnly
         placeholder={placeholder}
         value={selectedDate ? selectedDate.format('YYYY-MM-DD') : ''}

--- a/src/components/atoms/modal/Modal.tsx
+++ b/src/components/atoms/modal/Modal.tsx
@@ -9,6 +9,7 @@ interface ModalProps {
   className?: string;
   children: React.ReactNode;
   isDisabled?: boolean;
+  isLoading?: boolean;
   activeButtonName?: string;
   closeButtonName: string;
   title: string;
@@ -22,6 +23,7 @@ const Modal = React.forwardRef<HTMLDialogElement, ModalProps>(
       className,
       children,
       isDisabled,
+      isLoading,
       activeButtonName,
       closeButtonName,
       title,
@@ -66,6 +68,7 @@ const Modal = React.forwardRef<HTMLDialogElement, ModalProps>(
             {activeButtonName && activeFn && (
               <Button
                 isDisabled={isDisabled}
+                isLoading={isLoading}
                 label={activeButtonName}
                 styleType="primary"
                 sizeType="md"

--- a/src/components/composites/book/detail/BookDetail.tsx
+++ b/src/components/composites/book/detail/BookDetail.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
-import { useGetBookDetail } from '@/services';
+import { useUser } from '@/contexts';
+import { useGetBookDetail, useGetBookRecord } from '@/services';
 import type { GetBookRecordsServerModel } from '@/types';
 import BookInfoContent from './Info/BookDetailInfo';
 import BookRecordList from './record/BookRecordList';
@@ -10,8 +11,12 @@ const BookDetail = () => {
   const { id: isbn } = useParams();
 
   const query = isbn ? isbn.split(' ').filter((item) => item)[0] : '';
-  const req = { query };
-  const { data } = useGetBookDetail(req);
+  const { user } = useUser();
+  const { data: bookDetailInfo } = useGetBookDetail({ query });
+  const { data: bookRecordInfo } = useGetBookRecord({
+    userId: user?.id!,
+    isbn: query,
+  });
 
   const bookRecordServerData: GetBookRecordsServerModel = {
     pageInfo: {
@@ -82,11 +87,15 @@ const BookDetail = () => {
     ],
   };
 
-  if (!data) return null;
+  if (!bookDetailInfo) return null;
+  if (!bookRecordInfo) return null;
 
   return (
     <>
-      <BookInfoContent book={data.documents[0]} />
+      <BookInfoContent
+        book={bookDetailInfo.documents[0]}
+        records={bookRecordInfo}
+      />
       <BookRecordList bookRecordData={bookRecordServerData} />
     </>
   );

--- a/src/components/composites/book/detail/Info/BookDetailInfo.tsx
+++ b/src/components/composites/book/detail/Info/BookDetailInfo.tsx
@@ -3,18 +3,28 @@ import { useParams } from 'react-router-dom';
 
 import { Button } from '@/components';
 import { useModal } from '@/hooks';
-import type { GetBooksServerModel } from '@/types';
+import { getBookReadingStatus } from '@/utils';
+import { BOOK_READING_STATUS_OPTIONS } from '@/constants';
+import type { GetBookRecordServerModel, GetBooksServerModel } from '@/types';
 import BookReadingStatusChangeModal from './readingStatusChangeModal/BookReadingStatusChangeModal';
 import * as S from './BookDetailInfo.styled';
 
 interface BookInfoContentProps {
   book: GetBooksServerModel['documents'][number];
+  records: GetBookRecordServerModel;
 }
 
-const BookDetailInfo = ({ book }: BookInfoContentProps) => {
+const BookDetailInfo = ({ book, records }: BookInfoContentProps) => {
   const { id } = useParams();
 
   const { modalRef, openModal } = useModal();
+
+  const currentReadingStatus = records.length
+    ? getBookReadingStatus(
+        records[0].reading_start_at,
+        records[0].reading_end_at,
+      ) ?? BOOK_READING_STATUS_OPTIONS[0]
+    : BOOK_READING_STATUS_OPTIONS[0];
 
   return (
     <S.BookDetailSection>
@@ -34,7 +44,7 @@ const BookDetailInfo = ({ book }: BookInfoContentProps) => {
           <S.BookSubInfoWrapper>
             <S.BookSubInfoTitle>읽기 상태</S.BookSubInfoTitle>
             <S.BookSubInfoDescription>
-              <span>읽지 않음</span>
+              <span>{currentReadingStatus.label}</span>
               {/* TODO: 추후 위치 적절한지 고려한 후 수정 필요 */}
               <Button
                 styleType="tertiary"
@@ -44,7 +54,17 @@ const BookDetailInfo = ({ book }: BookInfoContentProps) => {
                   <BookReadingStatusChangeModal
                     ref={modalRef}
                     id={id}
-                    readingStatus="completed"
+                    readingStatus={currentReadingStatus}
+                    readingStartDateTime={
+                      records.length ? records[0].reading_start_at : null
+                    }
+                    readingEndDateTime={
+                      records.length ? records[0].reading_end_at : null
+                    }
+                    rating={records.length ? records[0].rating : null}
+                    recordContent={
+                      records.length ? records[0].record_comment : null
+                    }
                   />,
                 )}
               />

--- a/src/components/composites/book/detail/Info/BookDetailInfo.tsx
+++ b/src/components/composites/book/detail/Info/BookDetailInfo.tsx
@@ -54,6 +54,7 @@ const BookDetailInfo = ({ book, records }: BookInfoContentProps) => {
                   <BookReadingStatusChangeModal
                     ref={modalRef}
                     id={id}
+                    recordId={records.length ? records[0].id : null}
                     readingStatus={currentReadingStatus}
                     readingStartDateTime={
                       records.length ? records[0].reading_start_at : null

--- a/src/components/composites/book/detail/Info/BookDetailInfo.tsx
+++ b/src/components/composites/book/detail/Info/BookDetailInfo.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
 
 import { Button } from '@/components';
 import { useModal } from '@/hooks';
@@ -11,6 +12,8 @@ interface BookInfoContentProps {
 }
 
 const BookDetailInfo = ({ book }: BookInfoContentProps) => {
+  const { id } = useParams();
+
   const { modalRef, openModal } = useModal();
 
   return (
@@ -40,6 +43,7 @@ const BookDetailInfo = ({ book }: BookInfoContentProps) => {
                 onClick={openModal(
                   <BookReadingStatusChangeModal
                     ref={modalRef}
+                    id={id}
                     readingStatus="completed"
                   />,
                 )}

--- a/src/components/composites/book/detail/Info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
+++ b/src/components/composites/book/detail/Info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
@@ -19,7 +19,6 @@ import {
   useCreateBookRecordStatus,
   useUpdateBookRecordStatus,
 } from '@/services';
-import { getBookReadingStatus } from '@/utils';
 import RatingIcon from '@/assets/icon/ic_rating.svg?react';
 import {
   BOOK_READING_STATUS_OPTIONS,
@@ -172,11 +171,6 @@ const BookReadingStatusChangeModal = React.forwardRef<
       return null;
     };
 
-    type ReadingTimeRange = {
-      readingStartDateTime: string | null;
-      readingEndDateTime: string | null;
-    };
-
     /*
       NOTE: 상황별 토스트
       1. '읽기 전', '읽기 중' -> '읽기 완료' (TOAST_MESSAGE.SUCCESS.UPDATE_READING_PENDING_STATUS) 
@@ -187,22 +181,10 @@ const BookReadingStatusChangeModal = React.forwardRef<
     */
     const getToastMessage = (
       recordId: string | null,
-      originRecordDateTime: ReadingTimeRange,
-      newRecordDateTime: ReadingTimeRange,
+      originReadingStatus: SelectOptionType,
+      newReadingStatus: SelectOptionType,
     ) => {
       // NOTE: 첫 독서 기록 생성
-      const originReadingStatus =
-        getBookReadingStatus(
-          originRecordDateTime.readingStartDateTime,
-          originRecordDateTime.readingEndDateTime,
-        ) ?? BOOK_READING_STATUS_OPTIONS[0];
-
-      const newReadingStatus =
-        getBookReadingStatus(
-          newRecordDateTime.readingStartDateTime,
-          newRecordDateTime.readingEndDateTime,
-        ) ?? BOOK_READING_STATUS_OPTIONS[0];
-
       if (!recordId) {
         return getToastMessageByStatus(newReadingStatus.key);
       }
@@ -282,15 +264,8 @@ const BookReadingStatusChangeModal = React.forwardRef<
 
         const toastMessage = getToastMessage(
           recordId,
-          { readingStartDateTime, readingEndDateTime },
-          {
-            readingStartDateTime: data.readingStartDateTime
-              ? data.readingStartDateTime.format()
-              : null,
-            readingEndDateTime: data.readingEndDateTime
-              ? data.readingEndDateTime.format()
-              : null,
-          },
+          readingStatus,
+          data.readingStatus!,
         );
 
         if (recordId) {

--- a/src/components/composites/book/detail/Info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
+++ b/src/components/composites/book/detail/Info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
@@ -125,7 +125,7 @@ const BookReadingStatusChangeModal = React.forwardRef<
     };
 
     const handleRatingMouseEnter = (index: number) => () => {
-      setValue('rating', index);
+      setValue('rating', index + 1);
     };
 
     const handleReadingStatusChange = handleSubmit((data) => {
@@ -173,7 +173,7 @@ const BookReadingStatusChangeModal = React.forwardRef<
         readingEndDateTime: readingEndDateTime
           ? dayjs(readingEndDateTime)
           : null,
-        rating,
+        rating: rating ?? 1,
         recordContent,
       });
     }, []);
@@ -239,7 +239,7 @@ const BookReadingStatusChangeModal = React.forwardRef<
                       <RatingIcon
                         key={i}
                         css={S.ratingIcon(
-                          i - 1 < (watch('rating') ? watch('rating')! : 0),
+                          i < (watch('rating') ? watch('rating')! : 1),
                         )}
                         onMouseEnter={handleRatingMouseEnter(i)}
                       />

--- a/src/components/composites/book/detail/Info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
+++ b/src/components/composites/book/detail/Info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
@@ -217,6 +217,13 @@ const BookReadingStatusChangeModal = React.forwardRef<
 
     const handleOptionSelect = (option: SelectOptionType) => () => {
       setValue('readingStatus', option);
+
+      if (
+        option.key === 'ongoing' &&
+        dayjs.isDayjs(watch('readingEndDateTime'))
+      ) {
+        setValue('readingEndDateTime', null);
+      }
     };
 
     const handleRatingMouseEnter = (index: number) => () => {

--- a/src/components/composites/book/detail/Info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
+++ b/src/components/composites/book/detail/Info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
@@ -15,20 +15,14 @@ import {
   Textarea,
 } from '@/components';
 import { useModal, useToast } from '@/hooks';
-import {
-  useCreateBookRecordStatus,
-  useUpdateBookRecordStatus,
-} from '@/services';
+import { useCreateBookRecord, useUpdateBookRecord } from '@/services';
 import RatingIcon from '@/assets/icon/ic_rating.svg?react';
 import {
   BOOK_READING_STATUS_OPTIONS,
   ERROR_MESSAGE,
   TOAST_MESSAGE,
 } from '@/constants';
-import type {
-  CreateBookRecordStateQueryModel,
-  SelectOptionType,
-} from '@/types';
+import type { CreateBookRecordQueryModel, SelectOptionType } from '@/types';
 import * as S from './BookReadingStatusChangeModal.styled';
 
 type Form = {
@@ -81,9 +75,9 @@ const BookReadingStatusChangeModal = React.forwardRef<
     });
 
     const { isPending: isCreateStatusLoading, mutate: createBookRecordStatus } =
-      useCreateBookRecordStatus();
+      useCreateBookRecord();
     const { isPending: isUpdateStatusLoading, mutate: updateBookRecordStatus } =
-      useUpdateBookRecordStatus();
+      useUpdateBookRecord();
     const { user } = useUser();
     const { addToast } = useToast();
     const { closeModal } = useModal();
@@ -256,7 +250,7 @@ const BookReadingStatusChangeModal = React.forwardRef<
           return;
         }
 
-        const req: CreateBookRecordStateQueryModel = {
+        const req: CreateBookRecordQueryModel = {
           userId: user?.id!,
           isbn,
           ...makeData(data),

--- a/src/components/composites/book/detail/Info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
+++ b/src/components/composites/book/detail/Info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
@@ -36,211 +36,231 @@ type Form = {
 
 interface BookReadingStatusChangeModalProps {
   id?: string;
-  readingStatus: string;
+  readingStatus: SelectOptionType;
+  readingStartDateTime: string | null;
+  readingEndDateTime: string | null;
+  rating: number | null;
+  recordContent: string | null;
 }
 
 const BookReadingStatusChangeModal = React.forwardRef<
   HTMLDialogElement,
   BookReadingStatusChangeModalProps
->(({ id, readingStatus }, ref) => {
-  const isbn = id ? id.split(' ').filter((item) => item)[0] : '';
-  console.log(id, isbn);
+>(
+  (
+    {
+      id,
+      readingStatus,
+      readingStartDateTime,
+      readingEndDateTime,
+      rating,
+      recordContent,
+    },
+    ref,
+  ) => {
+    const isbn = id ? id.split(' ').filter((item) => item)[0] : '';
+    console.log(id, isbn);
 
-  const {
-    formState: { errors },
-    watch,
-    register,
-    setValue,
-    handleSubmit,
-  } = useForm<Form>({
-    mode: 'onTouched',
-  });
-
-  const { isPending: isUpdateStatusLoading, mutate: updateBookRecordStatus } =
-    useUpdateBookRecordStatus();
-  const { user } = useUser();
-  const { addToast } = useToast();
-  const { closeModal } = useModal();
-
-  const selectDate = (type: 'start' | 'end') => (date: Dayjs) => {
-    if (type === 'start') {
-      setValue('readingStartDateTime', date);
-    }
-
-    if (type === 'end') {
-      setValue('readingEndDateTime', date);
-    }
-  };
-
-  const makeData = (data: Form) => {
-    if (data.readingStatus?.key === 'pending') {
-      return {
-        rating: null,
-        readingStartDate: null,
-        readingEndDate: null,
-        recordComment: null,
-      };
-    }
-    if (data.readingStatus?.key === 'ongoing') {
-      return {
-        rating: null,
-        readingStartDate: data.readingStartDateTime!.utc().format(),
-        readingEndDate: null,
-        recordComment: null,
-      };
-    }
-
-    return {
-      rating: data.rating,
-      readingStartDate: data.readingStartDateTime!.utc().format(),
-      readingEndDate: data.readingEndDateTime!.utc().format(),
-      recordComment: data.recordContent,
-    };
-  };
-
-  const handleOptionSelect = (option: SelectOptionType) => () => {
-    setValue('readingStatus', option);
-  };
-
-  const handleRatingMouseEnter = (index: number) => () => {
-    setValue('rating', index);
-  };
-
-  const handleReadingStatusChange = handleSubmit((data) => {
-    const req: UpdateBookRecordStateQueryModel = {
-      userId: user?.id!,
-      isbn,
-      ...makeData(data),
-    };
-
-    updateBookRecordStatus(req, {
-      onSuccess: () => {
-        addToast(TOAST_MESSAGE.SUCCESS.UPDATE_READING_COMPLETED_STATUS);
-        closeModal();
-      },
+    const {
+      formState: { errors },
+      watch,
+      register,
+      reset,
+      setValue,
+      handleSubmit,
+    } = useForm<Form>({
+      mode: 'onTouched',
     });
 
-    /*
+    const { isPending: isUpdateStatusLoading, mutate: updateBookRecordStatus } =
+      useUpdateBookRecordStatus();
+    const { user } = useUser();
+    const { addToast } = useToast();
+    const { closeModal } = useModal();
+
+    const selectDate = (type: 'start' | 'end') => (date: Dayjs) => {
+      if (type === 'start') {
+        setValue('readingStartDateTime', date);
+      }
+
+      if (type === 'end') {
+        setValue('readingEndDateTime', date);
+      }
+    };
+
+    const makeData = (data: Form) => {
+      if (data.readingStatus?.key === 'pending') {
+        return {
+          rating: null,
+          readingStartDate: null,
+          readingEndDate: null,
+          recordComment: null,
+        };
+      }
+      if (data.readingStatus?.key === 'ongoing') {
+        return {
+          rating: null,
+          readingStartDate: data.readingStartDateTime!.utc().format(),
+          readingEndDate: null,
+          recordComment: null,
+        };
+      }
+
+      return {
+        rating: data.rating,
+        readingStartDate: data.readingStartDateTime!.utc().format(),
+        readingEndDate: data.readingEndDateTime!.utc().format(),
+        recordComment: data.recordContent,
+      };
+    };
+
+    const handleOptionSelect = (option: SelectOptionType) => () => {
+      setValue('readingStatus', option);
+    };
+
+    const handleRatingMouseEnter = (index: number) => () => {
+      setValue('rating', index);
+    };
+
+    const handleReadingStatusChange = handleSubmit((data) => {
+      const req: UpdateBookRecordStateQueryModel = {
+        userId: user?.id!,
+        isbn,
+        ...makeData(data),
+      };
+
+      updateBookRecordStatus(req, {
+        onSuccess: () => {
+          addToast(TOAST_MESSAGE.SUCCESS.UPDATE_READING_COMPLETED_STATUS);
+          closeModal();
+        },
+      });
+
+      /*
       NOTE: 상황별 토스트
       1. '읽기 전', '읽기 중' -> '읽기 완료' (TOAST.SUCCESS.UPDATE_READING_PENDING_STATUS) 
       2. '읽기 전' -> '읽기 중' (TOAST.SUCCESS.UPDATE_READING_ONGOING_STATUS)
       3. '읽기 중' -> '읽기 전' (TOAST.SUCCESS.UPDATE_READING_PENDING_STATUS)
       4. '읽기 완료' -> '읽기 전' or '읽기 중' (TOAST.WARNING.UPDATE_READING_STATUS)
     */
-  });
+    });
 
-  useEffect(() => {
-    const initReadingStatusOption = BOOK_READING_STATUS_OPTIONS.find(
-      (option) => option.key === readingStatus,
-    );
+    useEffect(() => {
+      reset({
+        readingStatus,
+        readingStartDateTime: readingStartDateTime
+          ? dayjs(readingStartDateTime)
+          : null,
+        readingEndDateTime: readingEndDateTime
+          ? dayjs(readingEndDateTime)
+          : null,
+        rating,
+        recordContent,
+      });
+    }, []);
 
-    setValue(
-      'readingStatus',
-      initReadingStatusOption ?? BOOK_READING_STATUS_OPTIONS[0],
-    );
-  }, []);
-
-  return (
-    <Modal
-      ref={ref}
-      isDisabled={false}
-      isLoading={isUpdateStatusLoading}
-      activeButtonName="변경"
-      closeButtonName="닫기"
-      title="도서 읽기 상태 변경"
-      closeFn={closeModal}
-      activeFn={handleReadingStatusChange}
-    >
-      <SegmentedButton
-        css={S.readingStatusButtonGroup}
-        options={BOOK_READING_STATUS_OPTIONS}
-        selectedOption={watch('readingStatus')}
-        onClick={handleOptionSelect}
-      />
-      <S.DataSection>
-        {watch('readingStatus')?.key === 'pending' ? (
-          // TODO: 도서 '읽기 전' 상태일 때 하기와 같이 문구 임시 노출 (추후 수정 필요)
-          <S.EmptyDataWrapper>
-            <p>책을 한 번 읽어보세요 :)</p>
-          </S.EmptyDataWrapper>
-        ) : (
-          <>
-            <S.DataWrapper marginBottom="24px">
-              <S.Label
-                isRequired={
-                  watch('readingStatus')?.key === 'pending' ? false : true
-                }
-              >
-                독서 기간
-              </S.Label>
-              <S.DatePickerWrapper>
-                <DatePicker
-                  selectedDate={watch('readingStartDateTime')}
-                  placeholder="독서 시작 날짜를 선택하세요."
-                  selectDate={selectDate('start')}
-                />
-                <DatePicker
-                  isDisabled={watch('readingStatus')?.key === 'ongoing'}
-                  selectedDate={watch('readingEndDateTime')}
-                  placeholder="독서 종료 날짜를 선택하세요."
-                  selectDate={selectDate('end')}
-                />
-              </S.DatePickerWrapper>
-            </S.DataWrapper>
-            {watch('readingStatus')?.key === 'completed' && (
+    return (
+      <Modal
+        ref={ref}
+        isDisabled={false}
+        isLoading={isUpdateStatusLoading}
+        activeButtonName="변경"
+        closeButtonName="닫기"
+        title="도서 읽기 상태 변경"
+        closeFn={closeModal}
+        activeFn={handleReadingStatusChange}
+      >
+        <SegmentedButton
+          css={S.readingStatusButtonGroup}
+          options={BOOK_READING_STATUS_OPTIONS}
+          selectedOption={watch('readingStatus')}
+          onClick={handleOptionSelect}
+        />
+        <S.DataSection>
+          {watch('readingStatus')?.key === 'pending' ? (
+            // TODO: 도서 '읽기 전' 상태일 때 하기와 같이 문구 임시 노출 (추후 수정 필요)
+            <S.EmptyDataWrapper>
+              <p>책을 한 번 읽어보세요 :)</p>
+            </S.EmptyDataWrapper>
+          ) : (
+            <>
               <S.DataWrapper marginBottom="24px">
                 <S.Label
                   isRequired={
-                    watch('readingStatus')?.key === 'completed' ? true : false
+                    watch('readingStatus')?.key === 'pending' ? false : true
                   }
                 >
-                  평점
+                  독서 기간
                 </S.Label>
-                <S.RatingInfo>
-                  {Array.from({ length: 5 }, (_, i) => (
-                    <RatingIcon
-                      key={i}
-                      css={S.ratingIcon(
-                        i - 1 < (watch('rating') ? watch('rating')! : 0),
-                      )}
-                      onMouseEnter={handleRatingMouseEnter(i)}
-                    />
-                  ))}
-                </S.RatingInfo>
+                <S.DatePickerWrapper>
+                  <DatePicker
+                    selectedDate={watch('readingStartDateTime')}
+                    placeholder="독서 시작 날짜를 선택하세요."
+                    selectDate={selectDate('start')}
+                  />
+                  <DatePicker
+                    isDisabled={watch('readingStatus')?.key === 'ongoing'}
+                    selectedDate={watch('readingEndDateTime')}
+                    placeholder="독서 종료 날짜를 선택하세요."
+                    selectDate={selectDate('end')}
+                  />
+                </S.DatePickerWrapper>
               </S.DataWrapper>
-            )}
-            {watch('readingStatus')?.key === 'completed' && (
-              <S.DataWrapper>
-                <S.Label
-                  isRequired={
-                    watch('readingStatus')?.key === 'completed' ? true : false
-                  }
-                  htmlFor="recordContent"
-                >
-                  감상문
-                </S.Label>
-                <Textarea
-                  css={S.recordContent}
-                  hasError={!!errors.recordContent}
-                  id="recordContent"
-                  maxLength={1000}
-                  placeholder="감상문 내용을 입력해주세요."
-                  value={watch('recordContent') ?? ''}
-                  register={register('recordContent', {
-                    required: ERROR_MESSAGE.REQUIRED,
-                  })}
-                />
-                {errors.recordContent?.message && (
-                  <ErrorMessage message={errors.recordContent.message} />
-                )}
-              </S.DataWrapper>
-            )}
-          </>
-        )}
-      </S.DataSection>
-    </Modal>
-  );
-});
+              {watch('readingStatus')?.key === 'completed' && (
+                <S.DataWrapper marginBottom="24px">
+                  <S.Label
+                    isRequired={
+                      watch('readingStatus')?.key === 'completed' ? true : false
+                    }
+                  >
+                    평점
+                  </S.Label>
+                  <S.RatingInfo>
+                    {Array.from({ length: 5 }, (_, i) => (
+                      <RatingIcon
+                        key={i}
+                        css={S.ratingIcon(
+                          i - 1 < (watch('rating') ? watch('rating')! : 0),
+                        )}
+                        onMouseEnter={handleRatingMouseEnter(i)}
+                      />
+                    ))}
+                  </S.RatingInfo>
+                </S.DataWrapper>
+              )}
+              {watch('readingStatus')?.key === 'completed' && (
+                <S.DataWrapper>
+                  <S.Label
+                    isRequired={
+                      watch('readingStatus')?.key === 'completed' ? true : false
+                    }
+                    htmlFor="recordContent"
+                  >
+                    감상문
+                  </S.Label>
+                  <Textarea
+                    css={S.recordContent}
+                    hasError={!!errors.recordContent}
+                    id="recordContent"
+                    maxLength={1000}
+                    placeholder="감상문 내용을 입력해주세요."
+                    value={watch('recordContent') ?? ''}
+                    register={register('recordContent', {
+                      required: ERROR_MESSAGE.REQUIRED,
+                    })}
+                  />
+                  {errors.recordContent?.message && (
+                    <ErrorMessage message={errors.recordContent.message} />
+                  )}
+                </S.DataWrapper>
+              )}
+            </>
+          )}
+        </S.DataSection>
+      </Modal>
+    );
+  },
+);
 
 export default BookReadingStatusChangeModal;
 

--- a/src/constants/db.ts
+++ b/src/constants/db.ts
@@ -1,0 +1,4 @@
+export const DB_TABLE_NAME = {
+  AUTH: 'users',
+  BOOK_RECORD: 'book_record',
+} as const;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 export * from './common';
+export * from './db';
 export * from './message';
 export * from './options';
 export * from './toast';

--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -13,6 +13,7 @@ export const ERROR_MESSAGE = {
   MIN_LENGTH_NICKNAME: `닉네임은 ${NICKNAME_MIN_LENGTH}자 이상이어야 합니다.`,
   PASSWORD_NOT_MATCH: '비밀번호가 일치하지 않습니다.',
   REQUIRED: '필수 값입니다.',
+  START_DATE_BEFORE_THAN_END_DATE: `'시작 날짜' 이후로 선택해주세요.`,
 };
 
 export const PASS_MESSAGE = {

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -45,6 +45,10 @@ export const TOAST_MESSAGE = {
       type: 'warning',
       message: `'읽기 완료' 상태에서 다른 상태로 변경할 수 없습니다 :(`,
     },
+    END_DATE_BEFORE_THAN_START_DATE: {
+      type: 'warning',
+      message: `'종료 날짜'가 '시작 날짜'보다 이후여야 합니다.`,
+    },
   },
   INFO: {
     CHECK_NICKNAME: {

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -20,6 +20,10 @@ export const TOAST_MESSAGE = {
       type: 'success',
       message: `'읽기 완료' 상태 변경 완료!`,
     },
+    UPDATE_RECORD_CONTENT: {
+      type: 'success',
+      message: '독서 기록 내용이 변경 되었습니다!',
+    },
   },
   WARNING: {
     AUTH_ALREADY_REGISTERED: {
@@ -39,7 +43,7 @@ export const TOAST_MESSAGE = {
     },
     UPDATE_READING_STATUS: {
       type: 'warning',
-      message: '상태를 변경할 수 없습니다 :(',
+      message: `'읽기 완료' 상태에서 다른 상태로 변경할 수 없습니다 :(`,
     },
   },
   INFO: {

--- a/src/services/book.ts
+++ b/src/services/book.ts
@@ -3,13 +3,12 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { getBookDetailAPI, getBooksAPI } from '@/apis';
 import type { GetBookDetailQueryModel, GetBooksQueryModel } from '@/types';
 
-const bookKeys = {
+export const bookKeys = {
   all: ['book'] as const,
   lists: () => [...bookKeys.all, 'list'] as const,
   list: (req: GetBooksQueryModel) => [...bookKeys.lists(), req] as const,
   details: () => [...bookKeys.all, 'detail'] as const,
-  detail: (req: GetBookDetailQueryModel) =>
-    [...bookKeys.details(), req] as const,
+  detail: (isbn: string) => [...bookKeys.details(), isbn] as const,
 };
 
 export const useGetBooks = (req: GetBooksQueryModel) => {
@@ -21,7 +20,7 @@ export const useGetBooks = (req: GetBooksQueryModel) => {
 
 export const useGetBookDetail = (req: GetBookDetailQueryModel) => {
   return useSuspenseQuery({
-    queryKey: bookKeys.detail(req),
+    queryKey: bookKeys.detail(req.query),
     queryFn: () => (req.query ? getBookDetailAPI(req) : null),
   });
 };

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './book';
+export * from './record';
 export { default as queryClient } from './queryClient';

--- a/src/services/record.ts
+++ b/src/services/record.ts
@@ -1,11 +1,26 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 
-import { updateBookRecordState } from '@/apis';
-import type { UpdateBookRecordStateQueryModel } from '@/types';
+import { getBookRecordAPI, updateBookRecordStateAPI } from '@/apis';
+import type {
+  GetBookRecordQueryModel,
+  UpdateBookRecordStateQueryModel,
+} from '@/types';
+import { bookKeys } from './book';
+
+const bookRecordKeys = {
+  record: (isbn: string) => [...bookKeys.detail(isbn), 'record'] as const,
+};
+
+export const useGetBookRecord = (req: GetBookRecordQueryModel) => {
+  return useSuspenseQuery({
+    queryKey: bookRecordKeys.record(req.isbn),
+    queryFn: () => getBookRecordAPI(req),
+  });
+};
 
 export const useUpdateBookRecordStatus = () => {
   return useMutation({
     mutationFn: (req: UpdateBookRecordStateQueryModel) =>
-      updateBookRecordState(req),
+      updateBookRecordStateAPI(req),
   });
 };

--- a/src/services/record.ts
+++ b/src/services/record.ts
@@ -1,14 +1,14 @@
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 
 import {
-  createBookRecordStateAPI,
+  createBookRecordAPI,
   getBookRecordAPI,
-  updateBookRecordStateAPI,
+  updateBookRecordAPI,
 } from '@/apis';
 import type {
-  CreateBookRecordStateQueryModel,
+  CreateBookRecordQueryModel,
   GetBookRecordQueryModel,
-  UpdateBookRecordStateQueryModel,
+  UpdateBookRecordQueryModel,
 } from '@/types';
 import queryClient from './queryClient';
 import { bookKeys } from './book';
@@ -24,10 +24,9 @@ export const useGetBookRecord = (req: GetBookRecordQueryModel) => {
   });
 };
 
-export const useCreateBookRecordStatus = () => {
+export const useCreateBookRecord = () => {
   return useMutation({
-    mutationFn: (req: CreateBookRecordStateQueryModel) =>
-      createBookRecordStateAPI(req),
+    mutationFn: (req: CreateBookRecordQueryModel) => createBookRecordAPI(req),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: bookRecordKeys.record(variables.isbn),
@@ -36,10 +35,9 @@ export const useCreateBookRecordStatus = () => {
   });
 };
 
-export const useUpdateBookRecordStatus = () => {
+export const useUpdateBookRecord = () => {
   return useMutation({
-    mutationFn: (req: UpdateBookRecordStateQueryModel) =>
-      updateBookRecordStateAPI(req),
+    mutationFn: (req: UpdateBookRecordQueryModel) => updateBookRecordAPI(req),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: bookRecordKeys.record(variables.isbn),

--- a/src/services/record.ts
+++ b/src/services/record.ts
@@ -5,6 +5,7 @@ import type {
   GetBookRecordQueryModel,
   UpdateBookRecordStateQueryModel,
 } from '@/types';
+import queryClient from './queryClient';
 import { bookKeys } from './book';
 
 const bookRecordKeys = {
@@ -22,5 +23,10 @@ export const useUpdateBookRecordStatus = () => {
   return useMutation({
     mutationFn: (req: UpdateBookRecordStateQueryModel) =>
       updateBookRecordStateAPI(req),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: bookRecordKeys.record(variables.isbn),
+      });
+    },
   });
 };

--- a/src/services/record.ts
+++ b/src/services/record.ts
@@ -1,7 +1,12 @@
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 
-import { getBookRecordAPI, updateBookRecordStateAPI } from '@/apis';
+import {
+  createBookRecordStateAPI,
+  getBookRecordAPI,
+  updateBookRecordStateAPI,
+} from '@/apis';
 import type {
+  CreateBookRecordStateQueryModel,
   GetBookRecordQueryModel,
   UpdateBookRecordStateQueryModel,
 } from '@/types';
@@ -16,6 +21,18 @@ export const useGetBookRecord = (req: GetBookRecordQueryModel) => {
   return useSuspenseQuery({
     queryKey: bookRecordKeys.record(req.isbn),
     queryFn: () => getBookRecordAPI(req),
+  });
+};
+
+export const useCreateBookRecordStatus = () => {
+  return useMutation({
+    mutationFn: (req: CreateBookRecordStateQueryModel) =>
+      createBookRecordStateAPI(req),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: bookRecordKeys.record(variables.isbn),
+      });
+    },
   });
 };
 

--- a/src/services/record.ts
+++ b/src/services/record.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { updateBookRecordState } from '@/apis';
+import type { UpdateBookRecordStateQueryModel } from '@/types';
+
+export const useUpdateBookRecordStatus = () => {
+  return useMutation({
+    mutationFn: (req: UpdateBookRecordStateQueryModel) =>
+      updateBookRecordState(req),
+  });
+};

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -60,22 +60,6 @@ export interface GetBooksServerModel {
   }[];
 }
 
-export interface GetBookRecordsServerModel {
-  pageInfo: {
-    totalCount: number;
-    totalPages: number;
-  };
-  records: {
-    id: string;
-    userName: string;
-    createdDate: string;
-    profileImgSrc: string | null;
-    likeCount: number;
-    content: string;
-    rating: number;
-  }[];
-}
-
 export interface GetMyLibraryServerModel {
   pageInfo: {
     totalCount: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './book';
 export * from './common';
+export * from './record';

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -1,3 +1,19 @@
+export interface GetBookRecordQueryModel {
+  userId: string;
+  isbn: string;
+}
+
+export type GetBookRecordServerModel = {
+  created_at: string;
+  updated_at: string;
+  id: string;
+  isbn: string;
+  rating: number | null;
+  reading_start_at: string | null;
+  reading_end_at: string | null;
+  record_comment: string | null;
+}[];
+
 export interface UpdateBookRecordStateQueryModel {
   userId: string;
   isbn: string;

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -1,0 +1,25 @@
+export interface UpdateBookRecordStateQueryModel {
+  userId: string;
+  isbn: string;
+  rating: number | null;
+  readingStartDate: string | null;
+  readingEndDate: string | null;
+  recordComment: string | null;
+  bookMark?: boolean;
+}
+
+export interface GetBookRecordsServerModel {
+  pageInfo: {
+    totalCount: number;
+    totalPages: number;
+  };
+  records: {
+    id: string;
+    userName: string;
+    createdDate: string;
+    profileImgSrc: string | null;
+    likeCount: number;
+    content: string;
+    rating: number;
+  }[];
+}

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -14,7 +14,7 @@ export type GetBookRecordServerModel = {
   record_comment: string | null;
 }[];
 
-export interface CreateBookRecordStateQueryModel {
+export interface CreateBookRecordQueryModel {
   userId: string;
   isbn: string;
   rating: number | null;
@@ -24,8 +24,7 @@ export interface CreateBookRecordStateQueryModel {
   bookMark?: boolean;
 }
 
-export interface UpdateBookRecordStateQueryModel
-  extends CreateBookRecordStateQueryModel {
+export interface UpdateBookRecordQueryModel extends CreateBookRecordQueryModel {
   recordId: string;
 }
 

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -14,7 +14,7 @@ export type GetBookRecordServerModel = {
   record_comment: string | null;
 }[];
 
-export interface UpdateBookRecordStateQueryModel {
+export interface CreateBookRecordStateQueryModel {
   userId: string;
   isbn: string;
   rating: number | null;
@@ -22,6 +22,11 @@ export interface UpdateBookRecordStateQueryModel {
   readingEndDate: string | null;
   recordComment: string | null;
   bookMark?: boolean;
+}
+
+export interface UpdateBookRecordStateQueryModel
+  extends CreateBookRecordStateQueryModel {
+  recordId: string;
 }
 
 export interface GetBookRecordsServerModel {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './record';

--- a/src/utils/record.ts
+++ b/src/utils/record.ts
@@ -1,0 +1,17 @@
+import { BOOK_READING_STATUS_OPTIONS } from '@/constants';
+
+const findReadingStatusOption = (
+  status: (typeof BOOK_READING_STATUS_OPTIONS)[number]['key'],
+) => BOOK_READING_STATUS_OPTIONS.find((option) => option.key === status);
+
+export const getBookReadingStatus = (
+  readingStartDate: string | null,
+  readingEndDate: string | null,
+) => {
+  if (readingStartDate && readingEndDate)
+    return findReadingStatusOption('completed');
+
+  if (readingStartDate) return findReadingStatusOption('ongoing');
+
+  return findReadingStatusOption('pending');
+};


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature -> main

### 변경 사항
1. API 연동
   a. **<ins>독서 기록 생성, 업데이트 API 연동</ins>**
&nbsp; &nbsp; i.  생성/업데이트 분리 (commit: d0ff10d0cfa5ff2714f0ec06927936d4fdcafba3)
&nbsp;&nbsp;&nbsp;&nbsp; -> 이유: update 시 `recordId` 에 해당하는 독서 감상문의 독서 상태에 따른 에러 처리를 하기 위함  (insert 경우는 필요 없음)
   b. 특정 도서에 대한 나의 독서 정보 조회 API 연동

2. 기능 추가
    a. **독서 기록 변경 시 조건에 따른 토스트 문구 노출 처리** (커밋: 138ac6510e352a43c0fd2af65179325fb44de2d1)
    b. 독서 종료 날짜를 시작 날짜 이전으로 설정할 경우 에러 처리
    c. 독서 날짜 특정 상태(`ongoing`, `completed`) 일 때 필수값 체크 및 날짜 선택 시 에러 초기화 처리 
    d. 독서 '진행 중' 상태 클릭 시 종료 날짜 선택되어 있을 경우 값 초기화 처리
 
3. 오류 수정
   a. 독서 평점 초기값 오류 수정(초기 null일 때 1로 default 처리)
   b. 독서 평점 계산 로직 수정(0, 1, 2, ... -> 1, 2, 3,...)

4. prop 수정
     a. Modal => `isLoading` 추가
     b. DatePicker => `hasError` 추가


### 참고 사항
