### PR TITLE
유저들의 독서 감상문 리스트 조회 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@tanstack/react-query": "^5.29.2",
+        "@tanstack/react-query-devtools": "^5.32.1",
         "@types/react-router-dom": "^5.3.3",
         "axios": "^1.6.8",
         "dayjs": "^1.11.10",
@@ -5788,26 +5789,51 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.29.0.tgz",
-      "integrity": "sha512-WgPTRs58hm9CMzEr5jpISe8HXa3qKQ8CxewdYZeVnA54JrPY9B1CZiwsCoLpLkf0dGRZq+LcX5OiJb0bEsOFww==",
+      "version": "5.32.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.32.1.tgz",
+      "integrity": "sha512-mCWa1wdGb1jiny4+qYegbSeadcFj+Nq65KFSs4A1DRveoIq7SrTwUhqu7hrB6d54cQH5x59DfJvxusn3w1Cj/g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.32.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.32.1.tgz",
+      "integrity": "sha512-7Xq57Ctopiy/4atpb0uNY5VRuCqRS/1fi/WBCKKX6jHMa6cCgDuV/AQuiwRXcKARbq2OkVAOrW2v4xK9nTbcCA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.29.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.29.2.tgz",
-      "integrity": "sha512-nyuWILR4u7H5moLGSiifLh8kIqQDLNOHGuSz0rcp+J75fNc8aQLyr5+I2JCHU3n+nJrTTW1ssgAD8HiKD7IFBQ==",
+      "version": "5.32.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.32.1.tgz",
+      "integrity": "sha512-+nXLMB0JK0XwTJ+lQt49DPNLrbSppni9N5W5yMR085yW3YaRKRUFhfVTER3TvQd1UycHpoGPFnt1gHiijXERAg==",
       "dependencies": {
-        "@tanstack/query-core": "5.29.0"
+        "@tanstack/query-core": "5.32.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.32.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.32.1.tgz",
+      "integrity": "sha512-NjNRPgCReZxgY5f56gnoTCR47NznHlQR4w2cW/W8B0QY8afkbPPnRlfzofs2SwdFW7F37Ysgjm8jtolPTzfa2Q==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.32.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.32.1",
         "react": "^18.0.0"
       }
     },
@@ -19772,16 +19798,29 @@
       }
     },
     "@tanstack/query-core": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.29.0.tgz",
-      "integrity": "sha512-WgPTRs58hm9CMzEr5jpISe8HXa3qKQ8CxewdYZeVnA54JrPY9B1CZiwsCoLpLkf0dGRZq+LcX5OiJb0bEsOFww=="
+      "version": "5.32.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.32.1.tgz",
+      "integrity": "sha512-mCWa1wdGb1jiny4+qYegbSeadcFj+Nq65KFSs4A1DRveoIq7SrTwUhqu7hrB6d54cQH5x59DfJvxusn3w1Cj/g=="
+    },
+    "@tanstack/query-devtools": {
+      "version": "5.32.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.32.1.tgz",
+      "integrity": "sha512-7Xq57Ctopiy/4atpb0uNY5VRuCqRS/1fi/WBCKKX6jHMa6cCgDuV/AQuiwRXcKARbq2OkVAOrW2v4xK9nTbcCA=="
     },
     "@tanstack/react-query": {
-      "version": "5.29.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.29.2.tgz",
-      "integrity": "sha512-nyuWILR4u7H5moLGSiifLh8kIqQDLNOHGuSz0rcp+J75fNc8aQLyr5+I2JCHU3n+nJrTTW1ssgAD8HiKD7IFBQ==",
+      "version": "5.32.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.32.1.tgz",
+      "integrity": "sha512-+nXLMB0JK0XwTJ+lQt49DPNLrbSppni9N5W5yMR085yW3YaRKRUFhfVTER3TvQd1UycHpoGPFnt1gHiijXERAg==",
       "requires": {
-        "@tanstack/query-core": "5.29.0"
+        "@tanstack/query-core": "5.32.1"
+      }
+    },
+    "@tanstack/react-query-devtools": {
+      "version": "5.32.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.32.1.tgz",
+      "integrity": "sha512-NjNRPgCReZxgY5f56gnoTCR47NznHlQR4w2cW/W8B0QY8afkbPPnRlfzofs2SwdFW7F37Ysgjm8jtolPTzfa2Q==",
+      "requires": {
+        "@tanstack/query-devtools": "5.32.1"
       }
     },
     "@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@tanstack/react-query": "^5.29.2",
+    "@tanstack/react-query-devtools": "^5.32.1",
     "@types/react-router-dom": "^5.3.3",
     "axios": "^1.6.8",
     "dayjs": "^1.11.10",

--- a/src/apis/book.ts
+++ b/src/apis/book.ts
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
+import { supabase } from '@/lib';
 import type {
   GetBookDetailQueryModel,
+  // GetBookUserRecordsServerModel,
   GetBooksQueryModel,
   GetBooksServerModel,
 } from '@/types';
@@ -14,9 +16,62 @@ const Kakao = axios.create({
 });
 
 export const getBooksAPI = async (req: GetBooksQueryModel) => {
-  const { data } = await Kakao.get<GetBooksServerModel>('/v3/search/book', {
-    params: req,
-  });
+  const { data: book } = await Kakao.get<GetBooksServerModel>(
+    '/v3/search/book',
+    {
+      params: req,
+    },
+  );
+
+  const documents = await Promise.all(
+    book.documents.map(async (document) => {
+      const isbn = document.isbn
+        ? document.isbn.split(' ').filter((item) => item)[0]
+        : '';
+
+      // const { data: records, error: recordsError } = await supabase
+      //   .from('book_record')
+      //   .select('reading_start_at, reading_end_at')
+      //   .eq('user_id', req.userId)
+      //   .eq('isbn', isbn)
+      //   .returns<GetBookUserRecordsServerModel['records']>();
+
+      // if (recordsError) {
+      //   throw new Error(recordsError.message);
+      // }
+
+      const { data: ratingData, error: ratingError } = await supabase
+        .rpc('get_book_rating_summary', {
+          input_isbn: isbn,
+        })
+        .returns<
+          [
+            {
+              count: GetBooksServerModel['documents'][number]['record']['count'];
+              rating_total: GetBooksServerModel['documents'][number]['record']['count'];
+            },
+          ]
+        >();
+
+      if (ratingError) {
+        throw new Error(ratingError.message);
+      }
+
+      return {
+        ...document,
+        // myRecord: {
+        //   reading_start_at: records.length ? records[0].reading_start_at : null,
+        //   reading_end_at: records.length ? records[0].reading_end_at : null,
+        // },
+        record: {
+          ratingTotal: ratingData[0].rating_total,
+          count: ratingData[0].count,
+        },
+      };
+    }),
+  );
+
+  const data: GetBooksServerModel = { ...book, documents };
 
   return data;
 };

--- a/src/apis/book.ts
+++ b/src/apis/book.ts
@@ -18,9 +18,7 @@ const Kakao = axios.create({
 export const getBooksAPI = async (req: GetBooksQueryModel) => {
   const { data: book } = await Kakao.get<GetBooksServerModel>(
     '/v3/search/book',
-    {
-      params: req,
-    },
+    { params: req },
   );
 
   const documents = await Promise.all(

--- a/src/apis/book.ts
+++ b/src/apis/book.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 import { supabase } from '@/lib';
+import { getFirstIsbnSegment } from '@/utils';
 import type {
   GetBookDetailQueryModel,
   // GetBookUserRecordsServerModel,
@@ -23,9 +24,7 @@ export const getBooksAPI = async (req: GetBooksQueryModel) => {
 
   const documents = await Promise.all(
     book.documents.map(async (document) => {
-      const isbn = document.isbn
-        ? document.isbn.split(' ').filter((item) => item)[0]
-        : '';
+      const isbn = getFirstIsbnSegment(document.isbn);
 
       // const { data: records, error: recordsError } = await supabase
       //   .from('book_record')

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -4,6 +4,8 @@ import type {
   CreateBookRecordQueryModel,
   GetBookRecordQueryModel,
   GetBookRecordServerModel,
+  GetBookUserRecordsQueryModel,
+  GetBookUserRecordsServerModel,
   UpdateBookRecordQueryModel,
 } from '@/types';
 
@@ -65,6 +67,73 @@ export const updateBookRecordAPI = async (req: UpdateBookRecordQueryModel) => {
   if (error) {
     throw new Error(error.message);
   }
+
+  return data;
+};
+
+export const getBookUserRecordsAPI = async (
+  req: GetBookUserRecordsQueryModel,
+) => {
+  // NOTE: 쿼리 시작
+  let query = supabase
+    .from('book_record')
+    .select(
+      'created_at, updated_at, id, isbn, rating, reading_start_at, reading_end_at, record_comment, like_count, user_id, users(nickname, profile_url)',
+    )
+    .eq('isbn', req.isbn)
+    .not('rating', 'is', null)
+    .not('reading_start_at', 'is', null)
+    .not('reading_end_at', 'is', null)
+    .not('record_comment', 'is', null);
+
+  // NOTE: 정렬 방식 적용
+  if (req.sort === 'like') {
+    query = query.order('like_count', { ascending: false });
+  }
+  if (req.sort === 'recent') {
+    query = query.order('created_at', { ascending: false });
+  }
+
+  // NOTE: 페이징 적용
+  query = query.range(
+    (req.page - 1) * req.pageSize,
+    req.page * req.pageSize - 1,
+  );
+
+  // NOTE: 쿼리 실행
+  const { data: records, error: recordsError } = await query.returns<
+    GetBookUserRecordsServerModel['records']
+  >();
+
+  if (recordsError) {
+    throw new Error(recordsError.message);
+  }
+
+  const { data: ratingData, error: ratingError } = await supabase
+    .rpc('get_book_rating_summary', {
+      input_isbn: req.isbn,
+    })
+    .returns<
+      [
+        {
+          count: GetBookUserRecordsServerModel['pageInfo']['totalCount'];
+          rating_total: GetBookUserRecordsServerModel['ratingTotal'];
+        },
+      ]
+    >();
+
+  if (ratingError) {
+    throw new Error(ratingError.message);
+  }
+
+  const data: GetBookUserRecordsServerModel = {
+    ratingTotal: ratingData[0].rating_total,
+    records,
+    pageInfo: {
+      totalCount: ratingData[0].count,
+      totalPages: Math.ceil(ratingData[0].count / req.pageSize),
+    },
+  };
 
   return data;
 };

--- a/src/components/atoms/card/book/list/BookListCard.tsx
+++ b/src/components/atoms/card/book/list/BookListCard.tsx
@@ -3,11 +3,12 @@ import { Link, useSearchParams } from 'react-router-dom';
 
 import { Button } from '@/components';
 import RatingIcon from '@/assets/icon/ic_rating.svg?react';
-import { BOOK_READING_STATUS_OPTIONS } from '@/constants';
+// import { BOOK_READING_STATUS_OPTIONS } from '@/constants';
+// import type { SelectOptionType } from '@/types';
 import * as S from './BookListCard.styled';
 
 interface BookListCardProps {
-  readingStatus: (typeof BOOK_READING_STATUS_OPTIONS)[number]['key'];
+  // readingStatus: SelectOptionType;
   rating: number | null;
   isbn: string;
   thumbnail: string;
@@ -21,7 +22,7 @@ interface BookListCardProps {
 
 const BookListCard = ({
   isbn,
-  readingStatus,
+  // readingStatus,
   rating,
   thumbnail,
   bookTitle,
@@ -43,19 +44,12 @@ const BookListCard = ({
   return (
     <Link css={S.bookDetailLink} key={isbn} to={`/book/${isbn}`}>
       <S.Header>
-        <S.ReadingStatus>
-          {
-            BOOK_READING_STATUS_OPTIONS.find(
-              (option) => option.key === readingStatus,
-            )?.label
-          }
-        </S.ReadingStatus>
-        {rating && (
-          <S.RatingWrapper>
-            <RatingIcon css={S.ratingIcon} />
-            <S.Rating>{rating}</S.Rating>
-          </S.RatingWrapper>
-        )}
+        <S.ReadingStatus></S.ReadingStatus>
+        {/* <S.ReadingStatus>{readingStatus.label}</S.ReadingStatus> */}
+        <S.RatingWrapper>
+          <RatingIcon css={S.ratingIcon} />
+          <S.Rating>{rating ?? '-'} / 5</S.Rating>
+        </S.RatingWrapper>
       </S.Header>
       <S.Main>
         <S.BookThumbnail src={thumbnail} alt="book thumbnail" />

--- a/src/components/composites/book/detail/BookDetail.tsx
+++ b/src/components/composites/book/detail/BookDetail.tsx
@@ -7,6 +7,7 @@ import {
   useGetBookRecord,
   useGetBookUserRecords,
 } from '@/services';
+import { getFirstIsbnSegment } from '@/utils';
 import { BOOK_REVIEW_DROPDOWN_OPTIONS } from '@/constants';
 import { SelectOptionType } from '@/types';
 import BookInfoContent from './Info/BookDetailInfo';
@@ -16,7 +17,7 @@ const BookDetail = () => {
   const [searchParams] = useSearchParams();
   const { id: isbn } = useParams();
 
-  const query = isbn ? isbn.split(' ').filter((item) => item)[0] : '';
+  const query = getFirstIsbnSegment(isbn);
   const [selectedFilter, setSelectedFilter] = useState<SelectOptionType>(
     BOOK_REVIEW_DROPDOWN_OPTIONS[0],
   );

--- a/src/components/composites/book/detail/BookDetail.tsx
+++ b/src/components/composites/book/detail/BookDetail.tsx
@@ -1,16 +1,26 @@
-import React from 'react';
-import { useParams } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useParams, useSearchParams } from 'react-router-dom';
 
 import { useUser } from '@/contexts';
-import { useGetBookDetail, useGetBookRecord } from '@/services';
-import type { GetBookRecordsServerModel } from '@/types';
+import {
+  useGetBookDetail,
+  useGetBookRecord,
+  useGetBookUserRecords,
+} from '@/services';
+import { BOOK_REVIEW_DROPDOWN_OPTIONS } from '@/constants';
+import { SelectOptionType } from '@/types';
 import BookInfoContent from './Info/BookDetailInfo';
 import BookRecordList from './record/BookRecordList';
 
 const BookDetail = () => {
+  const [searchParams] = useSearchParams();
   const { id: isbn } = useParams();
 
   const query = isbn ? isbn.split(' ').filter((item) => item)[0] : '';
+  const [selectedFilter, setSelectedFilter] = useState<SelectOptionType>(
+    BOOK_REVIEW_DROPDOWN_OPTIONS[0],
+  );
+
   const { user } = useUser();
   const { data: bookDetailInfo } = useGetBookDetail({ query });
   const { data: bookRecordInfo } = useGetBookRecord({
@@ -18,85 +28,30 @@ const BookDetail = () => {
     isbn: query,
   });
 
-  const bookRecordServerData: GetBookRecordsServerModel = {
-    pageInfo: {
-      totalCount: 37,
-      totalPages: 4,
-    },
-    records: [
-      {
-        id: '1',
-        userName: '홍**',
-        createdDate: '2024-04-11T00:00:00.000+09:00',
-        profileImgSrc: null,
-        likeCount: 0,
-        content:
-          '이 책은 누구에게나 열려 있는 책이다. 모두에게 추천 될 만한 책이며, 남녀노소 편안하게 읽을 수 있다.',
-        rating: 5,
-      },
-      {
-        id: '2',
-        userName: '김**',
-        createdDate: '2024-04-10T00:00:00.000+09:00',
-        profileImgSrc: null,
-        likeCount: 25,
-        content: `많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n
-          많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n 많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n 많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n 많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n`,
-        rating: 2,
-      },
-      {
-        id: '3',
-        userName: '홍**',
-        createdDate: '2024-04-11T00:00:00.000+09:00',
-        profileImgSrc: null,
-        likeCount: 0,
-        content:
-          '이 책은 누구에게나 열려 있는 책이다. 모두에게 추천 될 만한 책이며, 남녀노소 편안하게 읽을 수 있다.',
-        rating: 5,
-      },
-      {
-        id: '4',
-        userName: '김**',
-        createdDate: '2024-04-10T00:00:00.000+09:00',
-        profileImgSrc: null,
-        likeCount: 25,
-        content: `많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n
-          많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n 많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n 많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n 많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n`,
-        rating: 2,
-      },
-      {
-        id: '5',
-        userName: '홍**',
-        createdDate: '2024-04-11T00:00:00.000+09:00',
-        profileImgSrc: null,
-        likeCount: 0,
-        content:
-          '이 책은 누구에게나 열려 있는 책이다. 모두에게 추천 될 만한 책이며, 남녀노소 편안하게 읽을 수 있다.',
-        rating: 5,
-      },
-      {
-        id: '6',
-        userName: '김**',
-        createdDate: '2024-04-10T00:00:00.000+09:00',
-        profileImgSrc: null,
-        likeCount: 25,
-        content: `많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n
-          많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n 많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n 많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n 많은 분들이 추천하여 기대를 가지고 읽어보았지만, 돈이 너무나 아까웠다. 다시는 읽지 않을 책이다.\n`,
-        rating: 2,
-      },
-    ],
-  };
+  const { data: bookUserRecordInfo } = useGetBookUserRecords({
+    isbn: query,
+    page: searchParams.get('page') ? +searchParams.get('page')! : 1,
+    pageSize: 10,
+    sort: selectedFilter.key as 'like' | 'recent',
+  });
 
-  if (!bookDetailInfo) return null;
-  if (!bookRecordInfo) return null;
+  const handleRecordSortSelect = (option: SelectOptionType) => {
+    setSelectedFilter(option);
+  };
 
   return (
     <>
       <BookInfoContent
-        book={bookDetailInfo.documents[0]}
+        book={bookDetailInfo?.documents[0]}
         records={bookRecordInfo}
+        ratingTotal={bookUserRecordInfo.ratingTotal}
+        recordTotalCount={bookUserRecordInfo.pageInfo.totalCount}
       />
-      <BookRecordList bookRecordData={bookRecordServerData} />
+      <BookRecordList
+        bookRecordData={bookUserRecordInfo}
+        recordSort={selectedFilter}
+        onSortSelect={handleRecordSortSelect}
+      />
     </>
   );
 };

--- a/src/components/composites/book/detail/Info/BookDetailInfo.tsx
+++ b/src/components/composites/book/detail/Info/BookDetailInfo.tsx
@@ -3,18 +3,27 @@ import { useParams } from 'react-router-dom';
 
 import { Button } from '@/components';
 import { useModal } from '@/hooks';
-import { getBookReadingStatus } from '@/utils';
+import { formatNumber, getBookReadingStatus } from '@/utils';
 import { BOOK_READING_STATUS_OPTIONS } from '@/constants';
 import type { GetBookRecordServerModel, GetBooksServerModel } from '@/types';
 import BookReadingStatusChangeModal from './readingStatusChangeModal/BookReadingStatusChangeModal';
 import * as S from './BookDetailInfo.styled';
 
 interface BookInfoContentProps {
-  book: GetBooksServerModel['documents'][number];
+  book?: GetBooksServerModel['documents'][number];
   records: GetBookRecordServerModel;
+  ratingTotal: number | null;
+  recordTotalCount: number;
 }
 
-const BookDetailInfo = ({ book, records }: BookInfoContentProps) => {
+const BookDetailInfo = ({
+  book,
+  records,
+  ratingTotal,
+  recordTotalCount,
+}: BookInfoContentProps) => {
+  if (!book) return null;
+
   const { id } = useParams();
 
   const { modalRef, openModal } = useModal();
@@ -35,11 +44,16 @@ const BookDetailInfo = ({ book, records }: BookInfoContentProps) => {
         <S.BookSubInfoList>
           <S.BookSubInfoWrapper>
             <S.BookSubInfoTitle>평점</S.BookSubInfoTitle>
-            <S.BookSubInfoDescription>4.5 / 5</S.BookSubInfoDescription>
+            <S.BookSubInfoDescription>
+              {ratingTotal ? Math.floor(ratingTotal / recordTotalCount) : '-'} /
+              5
+            </S.BookSubInfoDescription>
           </S.BookSubInfoWrapper>
           <S.BookSubInfoWrapper>
             <S.BookSubInfoTitle>읽기 완료 수</S.BookSubInfoTitle>
-            <S.BookSubInfoDescription>123k</S.BookSubInfoDescription>
+            <S.BookSubInfoDescription>
+              {formatNumber(recordTotalCount)}
+            </S.BookSubInfoDescription>
           </S.BookSubInfoWrapper>
           <S.BookSubInfoWrapper>
             <S.BookSubInfoTitle>읽기 상태</S.BookSubInfoTitle>

--- a/src/components/composites/book/detail/Info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
+++ b/src/components/composites/book/detail/Info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/components';
 import { useModal, useToast } from '@/hooks';
 import { useCreateBookRecord, useUpdateBookRecord } from '@/services';
+import { getFirstIsbnSegment } from '@/utils';
 import RatingIcon from '@/assets/icon/ic_rating.svg?react';
 import {
   BOOK_READING_STATUS_OPTIONS,
@@ -59,7 +60,7 @@ const BookReadingStatusChangeModal = React.forwardRef<
     },
     ref,
   ) => {
-    const isbn = id ? id.split(' ').filter((item) => item)[0] : '';
+    const isbn = getFirstIsbnSegment(id);
 
     const {
       formState: { errors },

--- a/src/components/composites/book/detail/index.ts
+++ b/src/components/composites/book/detail/index.ts
@@ -1,2 +1,3 @@
 export * from './Info';
+export * from './record';
 export { default as BookDetail } from './BookDetail';

--- a/src/components/composites/book/detail/record/BookRecordList.tsx
+++ b/src/components/composites/book/detail/record/BookRecordList.tsx
@@ -1,29 +1,26 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { Pagination } from '@/components';
-import { BOOK_REVIEW_DROPDOWN_OPTIONS } from '@/constants';
-import type { GetBookRecordsServerModel, SelectOptionType } from '@/types';
+import type { GetBookUserRecordsServerModel, SelectOptionType } from '@/types';
 import BookRecordListData from './data/BookRecordListData';
 
 interface BookRecordListProps {
-  bookRecordData: GetBookRecordsServerModel;
+  bookRecordData: GetBookUserRecordsServerModel;
+  recordSort: SelectOptionType;
+  onSortSelect: (option: SelectOptionType) => void;
 }
 
-const BookRecordList = ({ bookRecordData }: BookRecordListProps) => {
-  const [selectedFilter, setSelectedFilter] = useState<SelectOptionType>(
-    BOOK_REVIEW_DROPDOWN_OPTIONS[0],
-  );
-
-  const handleReviewFilterSelect = (option: SelectOptionType) => {
-    setSelectedFilter(option);
-  };
-
+const BookRecordList = ({
+  bookRecordData,
+  recordSort,
+  onSortSelect,
+}: BookRecordListProps) => {
   return (
     <>
       <BookRecordListData
-        selectedFilter={selectedFilter}
+        recordSort={recordSort}
         records={bookRecordData.records}
-        onSelect={handleReviewFilterSelect}
+        onSelect={onSortSelect}
       />
       <Pagination
         totalPages={bookRecordData.pageInfo.totalPages}

--- a/src/components/composites/book/detail/record/BookRecordList.tsx
+++ b/src/components/composites/book/detail/record/BookRecordList.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { Pagination } from '@/components';
 import type { GetBookUserRecordsServerModel, SelectOptionType } from '@/types';
-import BookRecordListData from './data/BookRecordListData';
+import { BookRecordListData } from './data';
 
 interface BookRecordListProps {
   bookRecordData: GetBookUserRecordsServerModel;

--- a/src/components/composites/book/detail/record/data/BookRecordListData.skeleton.tsx
+++ b/src/components/composites/book/detail/record/data/BookRecordListData.skeleton.tsx
@@ -11,7 +11,6 @@ const BookRecordListDataSkeleton = () => {
         <S.RecordTitle>도서 감상 내용</S.RecordTitle>
         <Skeleton width={110} height={40} />
       </S.RecordHeader>
-
       {Array.from({ length: 5 }, (_, i) => (
         <S.RecordList key={i}>
           <S.RecordItemHeader>

--- a/src/components/composites/book/detail/record/data/BookRecordListData.skeleton.tsx
+++ b/src/components/composites/book/detail/record/data/BookRecordListData.skeleton.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import Skeleton from 'react-loading-skeleton';
+
+import LikeIcon from '@/assets/icon/ic_thumb_up.svg?react';
+import * as S from './BookRecordListData.styled';
+
+const BookRecordListDataSkeleton = () => {
+  return (
+    <S.RecordDataSection>
+      <S.RecordHeader>
+        <S.RecordTitle>도서 감상 내용</S.RecordTitle>
+        <Skeleton width={110} height={40} />
+      </S.RecordHeader>
+
+      {Array.from({ length: 5 }, (_, i) => (
+        <S.RecordList key={i}>
+          <S.RecordItemHeader>
+            <S.PersonInfo>
+              <Skeleton width={28} height={28} circle />
+              <Skeleton width={36} />
+              <Skeleton width={28} />
+            </S.PersonInfo>
+            <S.RatingInfo>
+              <Skeleton width={96} />
+            </S.RatingInfo>
+          </S.RecordItemHeader>
+          <S.RecordItemContent>
+            <Skeleton width="100%" height={48} />
+          </S.RecordItemContent>
+          <S.RecordItemFooter>
+            <S.LikeButton type="button" onClick={() => {}}>
+              <LikeIcon css={S.likeIcon} />
+              <S.Like>
+                <Skeleton width={16} />
+              </S.Like>
+            </S.LikeButton>
+          </S.RecordItemFooter>
+        </S.RecordList>
+      ))}
+    </S.RecordDataSection>
+  );
+};
+
+export default BookRecordListDataSkeleton;

--- a/src/components/composites/book/detail/record/data/BookRecordListData.tsx
+++ b/src/components/composites/book/detail/record/data/BookRecordListData.tsx
@@ -4,17 +4,17 @@ import { Dropdown, NoData, Profile } from '@/components';
 import LikeIcon from '@/assets/icon/ic_thumb_up.svg?react';
 import RatingIcon from '@/assets/icon/ic_rating.svg?react';
 import { BOOK_REVIEW_DROPDOWN_OPTIONS } from '@/constants';
-import type { GetBookRecordsServerModel, SelectOptionType } from '@/types';
+import type { GetBookUserRecordsServerModel, SelectOptionType } from '@/types';
 import * as S from './BookRecordListData.styled';
 
 interface BookRecordListDataProps {
-  selectedFilter: SelectOptionType;
-  records: GetBookRecordsServerModel['records'];
+  recordSort: SelectOptionType;
+  records: GetBookUserRecordsServerModel['records'];
   onSelect: (option: SelectOptionType) => void;
 }
 
 const BookRecordListData = ({
-  selectedFilter,
+  recordSort,
   records,
   onSelect,
 }: BookRecordListDataProps) => {
@@ -25,7 +25,7 @@ const BookRecordListData = ({
         <Dropdown
           css={S.filterDropdown}
           options={BOOK_REVIEW_DROPDOWN_OPTIONS}
-          selectedOption={selectedFilter}
+          selectedOption={recordSort}
           onSelect={onSelect}
         />
       </S.RecordHeader>
@@ -34,24 +34,22 @@ const BookRecordListData = ({
           <S.RecordList key={record.id}>
             <S.RecordItemHeader>
               <S.PersonInfo>
-                <Profile src={record.profileImgSrc} />
-                <S.UserName>{record.userName}</S.UserName>
-                <S.CreatedDate>
-                  {record.createdDate.split('T')[0]}
-                </S.CreatedDate>
+                <Profile src={record.users.profile_url} />
+                <S.UserName>{record.users.nickname}</S.UserName>
+                <S.CreatedDate>{record.created_at.split('T')[0]}</S.CreatedDate>
               </S.PersonInfo>
               <S.RatingInfo>
                 {Array.from({ length: 5 }, (_, i) => (
-                  <RatingIcon css={S.ratingIcon(i < record.rating)} />
+                  <RatingIcon css={S.ratingIcon(i < (record.rating ?? 0))} />
                 ))}
               </S.RatingInfo>
             </S.RecordItemHeader>
-            <S.RecordItemContent>{record.content}</S.RecordItemContent>
+            <S.RecordItemContent>{record.record_comment}</S.RecordItemContent>
             <S.RecordItemFooter>
               {/* TODO: 클릭 이벤트는 추후 작성 예정 */}
               <S.LikeButton type="button" onClick={() => {}}>
                 <LikeIcon css={S.likeIcon} />
-                <S.Like>{record.likeCount}</S.Like>
+                <S.Like>{record.like_count}</S.Like>
               </S.LikeButton>
             </S.RecordItemFooter>
           </S.RecordList>

--- a/src/components/composites/book/detail/record/data/BookRecordListData.tsx
+++ b/src/components/composites/book/detail/record/data/BookRecordListData.tsx
@@ -40,7 +40,10 @@ const BookRecordListData = ({
               </S.PersonInfo>
               <S.RatingInfo>
                 {Array.from({ length: 5 }, (_, i) => (
-                  <RatingIcon css={S.ratingIcon(i < (record.rating ?? 0))} />
+                  <RatingIcon
+                    key={i}
+                    css={S.ratingIcon(i < (record.rating ?? 0))}
+                  />
                 ))}
               </S.RatingInfo>
             </S.RecordItemHeader>

--- a/src/components/composites/book/detail/record/data/index.ts
+++ b/src/components/composites/book/detail/record/data/index.ts
@@ -1,0 +1,2 @@
+export { default as BookRecordListData } from './BookRecordListData';
+export { default as BookRecordListDataSkeleton } from './BookRecordListData.skeleton';

--- a/src/components/composites/book/detail/record/index.ts
+++ b/src/components/composites/book/detail/record/index.ts
@@ -1,0 +1,1 @@
+export * from './data';

--- a/src/components/composites/book/list/BookList.tsx
+++ b/src/components/composites/book/list/BookList.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+import { useUser } from '@/contexts';
 import { Pagination } from '@/components';
 import { useGetBooks } from '@/services';
 import SearchIcon from '@/assets/icon/ic_search.svg?react';
@@ -20,16 +21,18 @@ const BookList = () => {
     searchParams.get(key),
   );
 
+  const { user } = useUser();
+
   const req = {
     query: searchParams.get(target ? target.key : 'title') ?? '',
     sort: 'accuracy' as GetBooksQueryModel['sort'],
     page: searchParams.get('page') ? +searchParams.get('page')! : 1,
     size: 10,
     target: (target ? target.key : 'title') as GetBooksQueryModel['target'],
+    userId: user?.id!,
   };
 
   const { data } = useGetBooks(req);
-  // TODO: 'readingStatus', 'rating' 관련 조회 API 추가 필요
 
   useEffect(() => {
     if (noSearchRef) {

--- a/src/components/composites/book/list/data/BookListData.tsx
+++ b/src/components/composites/book/list/data/BookListData.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
 import { BookListCard, NoData } from '@/components';
+// import { getBookReadingStatus } from '@/utils';
+// import { BOOK_READING_STATUS_OPTIONS } from '@/constants';
 import type { GetBooksServerModel } from '@/types';
 
 interface BookListDataProps {
@@ -12,8 +14,17 @@ const BookListData = ({ books }: BookListDataProps) => {
     books.map((book) => (
       <BookListCard
         key={book.isbn}
-        readingStatus="pending" // TODO: 수정 예정
-        rating={4.5} // TODO: 수정 예정
+        // readingStatus={
+        //   getBookReadingStatus(
+        //     book.myRecord.reading_start_at,
+        //     book.myRecord.reading_end_at,
+        //   ) ?? BOOK_READING_STATUS_OPTIONS[0]
+        // }
+        rating={
+          book.record.ratingTotal
+            ? Math.floor(book.record.ratingTotal / book.record.count)
+            : null
+        }
         isbn={book.isbn}
         thumbnail={book.thumbnail}
         bookTitle={book.title}

--- a/src/components/layouts/login/LoginLayout.tsx
+++ b/src/components/layouts/login/LoginLayout.tsx
@@ -8,13 +8,13 @@ import * as S from './LoginLayout.styled';
 const LoginLayout = () => {
   const navigate = useNavigate();
 
-  const { user } = useUser();
+  const { isInitializing, user } = useUser();
 
   useEffect(() => {
-    if (user) {
-      navigate('/');
-    }
-  }, []);
+    if (!user || isInitializing) return;
+
+    navigate('/');
+  }, [isInitializing, user]);
 
   return user ? null : (
     <S.LoginLayout>

--- a/src/components/layouts/main/MainLayout.tsx
+++ b/src/components/layouts/main/MainLayout.tsx
@@ -1,17 +1,41 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
+import { useUser } from '@/contexts';
 import { Header, MobileHeader } from '@/components';
+import { useToast } from '@/hooks';
 import { deviceState } from '@/stores';
+import { TOAST_MESSAGE } from '@/constants';
 import * as S from './MainLayout.styled';
 
 interface MainLayoutProps {
   className?: string;
   children: React.ReactNode;
+  isAuth?: boolean;
 }
 
-const MainLayout = ({ className, children }: MainLayoutProps) => {
+const MainLayout = ({
+  className,
+  children,
+  isAuth = false,
+}: MainLayoutProps) => {
+  const navigate = useNavigate();
+
   const device = useRecoilValue(deviceState);
+
+  const { isInitializing, user } = useUser();
+  const { addToast } = useToast();
+
+  // NOTE: 로그인하지 않고 로그인이 필요한 페이지에 접근했을 경우 로그인 페이지로 라우팅 및 토스트 알림 처리
+  useEffect(() => {
+    if (isAuth && !user && !isInitializing) {
+      addToast(TOAST_MESSAGE.INFO.LOGIN);
+      navigate('/login');
+    }
+  }, [isAuth, isInitializing, user]);
+
+  if (isInitializing) return null;
 
   return (
     <>

--- a/src/constants/toast.ts
+++ b/src/constants/toast.ts
@@ -55,6 +55,10 @@ export const TOAST_MESSAGE = {
       type: 'info',
       message: '닉네임 중복 확인을 완료해주세요 :)',
     },
+    LOGIN: {
+      type: 'info',
+      message: '해당 서비스를 이용하기 위하여 로그인을 진행해주세요 :)',
+    },
     SERVICE_REPAIRING: {
       type: 'info',
       title: '서비스 준비중입니다.',

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -4,14 +4,17 @@ import { Session, User } from '@supabase/supabase-js';
 import { supabase } from '@/lib';
 
 export const AuthContext = createContext<{
+  isInitializing: boolean;
   user: User | null;
-  session: Session | null;
+  userSession: Session | null;
 }>({
+  isInitializing: true,
   user: null,
-  session: null,
+  userSession: null,
 });
 
 export const AuthContextProvider = (props: any) => {
+  const [isInitializing, setIsInitializing] = useState(true);
   const [userSession, setUserSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
 
@@ -29,12 +32,14 @@ export const AuthContextProvider = (props: any) => {
       },
     );
 
+    setIsInitializing(false);
+
     return () => {
       authListener.subscription.unsubscribe();
     };
   }, []);
 
-  const value = { userSession, user };
+  const value = { isInitializing, userSession, user };
   return <AuthContext.Provider value={value} {...props} />;
 };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom/client';
 import { RecoilRoot } from 'recoil';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import { AuthContextProvider } from './contexts';
 import { ModalPortal, Toast } from './components';
@@ -14,6 +15,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <AuthContextProvider>
       <QueryClientProvider client={queryClient}>
         <RecoilRoot>
+          <ReactQueryDevtools />
           <GlobalStyles />
           <Toast />
           <ModalPortal />

--- a/src/pages/book/[id]/index.tsx
+++ b/src/pages/book/[id]/index.tsx
@@ -1,11 +1,23 @@
 import React, { Suspense } from 'react';
 
-import { BookDetail, BookDetailInfoSkeleton, MainLayout } from '@/components';
+import {
+  BookDetail,
+  BookDetailInfoSkeleton,
+  BookRecordListDataSkeleton,
+  MainLayout,
+} from '@/components';
 
 const root = () => {
   return (
     <MainLayout>
-      <Suspense fallback={<BookDetailInfoSkeleton />}>
+      <Suspense
+        fallback={
+          <>
+            <BookDetailInfoSkeleton />
+            <BookRecordListDataSkeleton />
+          </>
+        }
+      >
         <BookDetail />
       </Suspense>
     </MainLayout>

--- a/src/pages/book/index.tsx
+++ b/src/pages/book/index.tsx
@@ -10,7 +10,7 @@ import * as S from './index.styled';
 
 const root = () => {
   return (
-    <MainLayout css={S.mainLayout}>
+    <MainLayout css={S.mainLayout} isAuth>
       <BookSearch />
       <Suspense fallback={<BookListSkeleton />}>
         <BookList />

--- a/src/services/record.ts
+++ b/src/services/record.ts
@@ -3,23 +3,29 @@ import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import {
   createBookRecordAPI,
   getBookRecordAPI,
+  getBookUserRecordsAPI,
   updateBookRecordAPI,
 } from '@/apis';
 import type {
   CreateBookRecordQueryModel,
   GetBookRecordQueryModel,
+  GetBookUserRecordsQueryModel,
   UpdateBookRecordQueryModel,
 } from '@/types';
 import queryClient from './queryClient';
 import { bookKeys } from './book';
 
 const bookRecordKeys = {
-  record: (isbn: string) => [...bookKeys.detail(isbn), 'record'] as const,
+  myRecord: (isbn: string) => [...bookKeys.detail(isbn), 'myRecord'] as const,
+  userRecords: (filter: GetBookUserRecordsQueryModel) => {
+    const { isbn, ...rest } = filter;
+    return [...bookKeys.detail(isbn), 'userRecords', rest] as const;
+  },
 };
 
 export const useGetBookRecord = (req: GetBookRecordQueryModel) => {
   return useSuspenseQuery({
-    queryKey: bookRecordKeys.record(req.isbn),
+    queryKey: bookRecordKeys.myRecord(req.isbn),
     queryFn: () => getBookRecordAPI(req),
   });
 };
@@ -29,7 +35,7 @@ export const useCreateBookRecord = () => {
     mutationFn: (req: CreateBookRecordQueryModel) => createBookRecordAPI(req),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
-        queryKey: bookRecordKeys.record(variables.isbn),
+        queryKey: bookRecordKeys.myRecord(variables.isbn),
       });
     },
   });
@@ -40,8 +46,15 @@ export const useUpdateBookRecord = () => {
     mutationFn: (req: UpdateBookRecordQueryModel) => updateBookRecordAPI(req),
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
-        queryKey: bookRecordKeys.record(variables.isbn),
+        queryKey: bookRecordKeys.myRecord(variables.isbn),
       });
     },
+  });
+};
+
+export const useGetBookUserRecords = (req: GetBookUserRecordsQueryModel) => {
+  return useSuspenseQuery({
+    queryKey: bookRecordKeys.userRecords(req),
+    queryFn: () => getBookUserRecordsAPI(req),
   });
 };

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -32,10 +32,26 @@ export interface GetBooksQueryModel {
   page: number;
   size: number;
   target: 'title' | 'isbn' | 'publisher' | 'person';
+  userId: string;
 }
 
 export interface GetBookDetailQueryModel {
   query: string;
+}
+
+interface Document {
+  authors: string[];
+  contents: string;
+  datetime: string;
+  isbn: string;
+  price: number;
+  publisher: string;
+  sale_price: number;
+  status: string;
+  thumbnail: string;
+  title: string;
+  translators: string[];
+  url: string;
 }
 
 export interface GetBooksServerModel {
@@ -44,20 +60,13 @@ export interface GetBooksServerModel {
     pageable_count: number;
     total_count: number;
   };
-  documents: {
-    authors: string[];
-    contents: string;
-    datetime: string;
-    isbn: string;
-    price: number;
-    publisher: string;
-    sale_price: number;
-    status: string;
-    thumbnail: string;
-    title: string;
-    translators: string[];
-    url: string;
-  }[];
+  documents: (Document & {
+    // myRecord: {
+    //   reading_start_at: string | null;
+    //   reading_end_at: string | null;
+    // };
+    record: { ratingTotal: number; count: number };
+  })[];
 }
 
 export interface GetMyLibraryServerModel {

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -26,3 +26,8 @@ export interface TabType extends SelectOptionType {
 }
 
 export type CheckboxGroupType<T extends string> = { [key in T]: boolean };
+
+export interface Pagination {
+  totalCount: number;
+  totalPages: number;
+}

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -1,9 +1,11 @@
+import type { Pagination } from '@/types';
+
 export interface GetBookRecordQueryModel {
   userId: string;
   isbn: string;
 }
 
-export type GetBookRecordServerModel = {
+type BookRecordServerData = {
   created_at: string;
   updated_at: string;
   id: string;
@@ -12,7 +14,10 @@ export type GetBookRecordServerModel = {
   reading_start_at: string | null;
   reading_end_at: string | null;
   record_comment: string | null;
-}[];
+  like_count: number;
+};
+
+export type GetBookRecordServerModel = BookRecordServerData[];
 
 export interface CreateBookRecordQueryModel {
   userId: string;
@@ -28,18 +33,17 @@ export interface UpdateBookRecordQueryModel extends CreateBookRecordQueryModel {
   recordId: string;
 }
 
-export interface GetBookRecordsServerModel {
-  pageInfo: {
-    totalCount: number;
-    totalPages: number;
-  };
-  records: {
-    id: string;
-    userName: string;
-    createdDate: string;
-    profileImgSrc: string | null;
-    likeCount: number;
-    content: string;
-    rating: number;
-  }[];
+export interface GetBookUserRecordsQueryModel {
+  isbn: string;
+  page: number;
+  pageSize: number;
+  sort: 'like' | 'recent';
+}
+
+export interface GetBookUserRecordsServerModel {
+  ratingTotal: number | null;
+  records: (BookRecordServerData & {
+    users: { nickname: string; profile_url: string | null };
+  })[];
+  pageInfo: Pagination;
 }

--- a/src/utils/book.ts
+++ b/src/utils/book.ts
@@ -1,0 +1,2 @@
+export const getFirstIsbnSegment = (isbn?: string) =>
+  isbn ? isbn.split(' ').filter((item) => item)[0] : '';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './number';
 export * from './record';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './book';
 export * from './number';
 export * from './record';

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,5 +1,5 @@
 export const formatNumber = (num: number, precision = 2) => {
-  const NUMBER_FORMAT_THRESHOLDS = [
+  const NUMBER_UNIT_SUFFIXES = [
     { suffix: 'T', threshold: 1e12 },
     { suffix: 'B', threshold: 1e9 },
     { suffix: 'M', threshold: 1e6 },
@@ -7,10 +7,13 @@ export const formatNumber = (num: number, precision = 2) => {
     { suffix: '', threshold: 1 },
   ];
 
-  const found = NUMBER_FORMAT_THRESHOLDS.find(
+  const matchedNumberFormat = NUMBER_UNIT_SUFFIXES.find(
     (x) => Math.abs(num) >= x.threshold,
   );
-  if (!found) return num;
+  if (!matchedNumberFormat) return num;
 
-  return (num / found.threshold).toFixed(precision) + found.suffix;
+  return (
+    (num / matchedNumberFormat.threshold).toFixed(precision) +
+    matchedNumberFormat.suffix
+  );
 };

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -1,0 +1,16 @@
+export const formatNumber = (num: number, precision = 2) => {
+  const NUMBER_FORMAT_THRESHOLDS = [
+    { suffix: 'T', threshold: 1e12 },
+    { suffix: 'B', threshold: 1e9 },
+    { suffix: 'M', threshold: 1e6 },
+    { suffix: 'K', threshold: 1e3 },
+    { suffix: '', threshold: 1 },
+  ];
+
+  const found = NUMBER_FORMAT_THRESHOLDS.find(
+    (x) => Math.abs(num) >= x.threshold,
+  );
+  if (!found) return num;
+
+  return (num / found.threshold).toFixed(precision) + found.suffix;
+};


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature -> main

### 변경 사항
1. 기능 추가
   a. **<ins>도서 상세 페이지 - 유저들의 독서 감상문 리스트 조회 기능</ins>**
   b. Auth 관련 초기화 진행 상태 추가
       -> **로그인하지 않은 유저가 로그인이 필요한 페이지에 접근했을 경우 토스트 알림과 함께 로그인 페이지로 리다이렉트 처리**
   c. 도서 목록 조회 시 각 도서의 평점 노출 
       (**'읽기 상태' 조회 기능도 구현하였으나, DB 접근 횟수가 많아져(한 페이지에 노출되는 도서 수 * 2(<ins>평균 평점 조회, 도서 읽기 상태 조회</ins>)) 주석 처리 진행**)

2. 스크린 수정 
   a. 유저들의 독서 감상문 리스트 스켈레톤 UI 제작
 
3. 리팩토링
   a. 로그인한 유저가 로그인 화면에 접근했을 경우 리다이렉트 로직 수정
       => 초기화 진행 상태 이용

4. 라이브러리 추가
     a. @tanstack/react-query-devtools

5. 기타사항 수정
     a. 반복문 key 추가


### 참고 사항
