### PR TITLE
Feature/#33 도서정보 DB캐싱 관련 작업

### DIFF
--- a/src/apis/book.ts
+++ b/src/apis/book.ts
@@ -4,6 +4,7 @@ import { supabase } from '@/lib';
 import { getFirstIsbnSegment } from '@/utils';
 import type {
   GetBookDetailQueryModel,
+  GetBookDetailServerModel,
   // GetBookUserRecordsServerModel,
   GetBooksQueryModel,
   GetBooksServerModel,
@@ -74,10 +75,25 @@ export const getBooksAPI = async (req: GetBooksQueryModel) => {
 };
 
 export const getBookDetailAPI = async (req: GetBookDetailQueryModel) => {
-  const { data } = await Kakao.get<GetBooksServerModel>(
+  const { data } = await Kakao.get<GetBookDetailServerModel>(
     '/v3/search/book?sort=accuracy&page=1&size=10&target=isbn',
     { params: req },
   );
+
+  await supabase.from('book').upsert({
+    isbn: data.documents[0].isbn,
+    title: data.documents[0].title,
+    contents: data.documents[0].contents,
+    thumbnail: data.documents[0].thumbnail,
+    authors: data.documents[0].authors,
+    publisher: data.documents[0].publisher,
+    url: data.documents[0].url,
+    datetime: data.documents[0].datetime,
+    translators: data.documents[0].translators,
+    price: data.documents[0].price,
+    sale_price: data.documents[0].sale_price,
+    status: data.documents[0].status,
+  });
 
   return data;
 };

--- a/src/components/composites/book/detail/BookDetail.tsx
+++ b/src/components/composites/book/detail/BookDetail.tsx
@@ -26,11 +26,11 @@ const BookDetail = () => {
   const { data: bookDetailInfo } = useGetBookDetail({ query });
   const { data: bookRecordInfo } = useGetBookRecord({
     userId: user?.id!,
-    isbn: query,
+    isbn: isbn!,
   });
 
   const { data: bookUserRecordInfo } = useGetBookUserRecords({
-    isbn: query,
+    isbn: isbn!,
     page: searchParams.get('page') ? +searchParams.get('page')! : 1,
     pageSize: 10,
     sort: selectedFilter.key as 'like' | 'recent',

--- a/src/components/composites/book/detail/info/BookDetailInfo.tsx
+++ b/src/components/composites/book/detail/info/BookDetailInfo.tsx
@@ -5,12 +5,15 @@ import { Button } from '@/components';
 import { useModal } from '@/hooks';
 import { formatNumber, getBookReadingStatus } from '@/utils';
 import { BOOK_READING_STATUS_OPTIONS } from '@/constants';
-import type { GetBookRecordServerModel, GetBooksServerModel } from '@/types';
+import type {
+  GetBookDetailServerModel,
+  GetBookRecordServerModel,
+} from '@/types';
 import BookReadingStatusChangeModal from './readingStatusChangeModal/BookReadingStatusChangeModal';
 import * as S from './BookDetailInfo.styled';
 
 interface BookInfoContentProps {
-  book?: GetBooksServerModel['documents'][number];
+  book?: GetBookDetailServerModel['documents'][number];
   records: GetBookRecordServerModel;
   ratingTotal: number | null;
   recordTotalCount: number;

--- a/src/components/composites/book/detail/info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
+++ b/src/components/composites/book/detail/info/readingStatusChangeModal/BookReadingStatusChangeModal.tsx
@@ -16,7 +16,6 @@ import {
 } from '@/components';
 import { useModal, useToast } from '@/hooks';
 import { useCreateBookRecord, useUpdateBookRecord } from '@/services';
-import { getFirstIsbnSegment } from '@/utils';
 import RatingIcon from '@/assets/icon/ic_rating.svg?react';
 import {
   BOOK_READING_STATUS_OPTIONS,
@@ -60,8 +59,6 @@ const BookReadingStatusChangeModal = React.forwardRef<
     },
     ref,
   ) => {
-    const isbn = getFirstIsbnSegment(id);
-
     const {
       formState: { errors },
       watch,
@@ -253,7 +250,7 @@ const BookReadingStatusChangeModal = React.forwardRef<
 
         const req: CreateBookRecordQueryModel = {
           userId: user?.id!,
-          isbn,
+          isbn: id!,
           ...makeData(data),
         };
 

--- a/src/components/layouts/main/MainLayout.tsx
+++ b/src/components/layouts/main/MainLayout.tsx
@@ -1,12 +1,10 @@
-import React, { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React from 'react';
+import { Navigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import { useUser } from '@/contexts';
 import { Header, MobileHeader } from '@/components';
-import { useToast } from '@/hooks';
 import { deviceState } from '@/stores';
-import { TOAST_MESSAGE } from '@/constants';
 import * as S from './MainLayout.styled';
 
 interface MainLayoutProps {
@@ -20,22 +18,12 @@ const MainLayout = ({
   children,
   isAuth = false,
 }: MainLayoutProps) => {
-  const navigate = useNavigate();
-
   const device = useRecoilValue(deviceState);
 
   const { isInitializing, user } = useUser();
-  const { addToast } = useToast();
-
-  // NOTE: 로그인하지 않고 로그인이 필요한 페이지에 접근했을 경우 로그인 페이지로 라우팅 및 토스트 알림 처리
-  useEffect(() => {
-    if (isAuth && !user && !isInitializing) {
-      addToast(TOAST_MESSAGE.INFO.LOGIN);
-      navigate('/login');
-    }
-  }, [isAuth, isInitializing, user]);
 
   if (isInitializing) return null;
+  if (!user && isAuth) return <Navigate to="/login" />;
 
   return (
     <>

--- a/src/services/record.ts
+++ b/src/services/record.ts
@@ -49,6 +49,12 @@ export const useCreateBookRecord = () => {
       queryClient.invalidateQueries({
         queryKey: bookRecordKeys.myRecord(variables.isbn),
       });
+
+      if (variables.readingStartDate && variables.readingEndDate) {
+        queryClient.invalidateQueries({
+          queryKey: bookRecordKeys.userRecords(variables.isbn),
+        });
+      }
     },
   });
 };
@@ -60,6 +66,12 @@ export const useUpdateBookRecord = () => {
       queryClient.invalidateQueries({
         queryKey: bookRecordKeys.myRecord(variables.isbn),
       });
+
+      if (variables.readingStartDate && variables.readingEndDate) {
+        queryClient.invalidateQueries({
+          queryKey: bookRecordKeys.userRecords(variables.isbn),
+        });
+      }
     },
   });
 };

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -69,6 +69,15 @@ export interface GetBooksServerModel {
   })[];
 }
 
+export interface GetBookDetailServerModel {
+  meta: {
+    is_end: boolean;
+    pageable_count: number;
+    total_count: number;
+  };
+  documents: Document[];
+}
+
 export interface GetMyLibraryServerModel {
   pageInfo: {
     totalCount: number;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타

### 반영 브랜치
- feature -> main

### 변경 사항
1. 도서 상세 정보 조회 시 도서 DB에 해당 정보 추가
    (추후 유저들의 현재 읽고 있는 도서 정보 및 베스트 감상문에 활용할 예정)

2. 도서 DB 만들면서 도서 감상문 DB의 `isbn` 정보를 도서 DB의 외래키로 변경 관련하여, 
    기존 도서 감상문 DB `isbn`에 '10자리' 형태로 파싱해서 넣고 있었는데
     원본 그대로 '10자리' or '10자리 13자리' 형태로 넣도록 수정

3. 도서 읽기 상태 '완료'로 변경 시 하단에 유저 감상문 리스트 쿼리 캐싱 무효화 처리하여 reload 할 수 있도록 작업

4. 페이지 권한이 없는 사용자의 경우 로그인 페이지로 리다이렉트하는 부분 '토스트 노출' 삭제하고, `useEffect` -> `if문` 변경 
    



### 참고 사항
