### PR TITLE
독서 기록 조회, 주간 베스트 독서 감상문 조회 API 연동

### DIFF
--- a/src/apis/book.ts
+++ b/src/apis/book.ts
@@ -25,8 +25,6 @@ export const getBooksAPI = async (req: GetBooksQueryModel) => {
 
   const documents = await Promise.all(
     book.documents.map(async (document) => {
-      const isbn = getFirstIsbnSegment(document.isbn);
-
       // const { data: records, error: recordsError } = await supabase
       //   .from('book_record')
       //   .select('reading_start_at, reading_end_at')
@@ -40,7 +38,7 @@ export const getBooksAPI = async (req: GetBooksQueryModel) => {
 
       const { data: ratingData, error: ratingError } = await supabase
         .rpc('get_book_rating_summary', {
-          input_isbn: isbn,
+          input_isbn: document.isbn,
         })
         .returns<
           [

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './book';
+export * from './myLibrary';
 export * from './record';

--- a/src/apis/myLibrary.ts
+++ b/src/apis/myLibrary.ts
@@ -1,0 +1,49 @@
+import { supabase } from '@/lib';
+import { DB_TABLE_NAME } from '@/constants';
+import type { GetMyLibraryQueryModel, GetMyLibraryServerModel } from '@/types';
+
+export const getMyLibrariesAPI = async (req: GetMyLibraryQueryModel) => {
+  // NOTE: 쿼리 시작
+  let query = supabase
+    .from(DB_TABLE_NAME.BOOK_RECORD)
+    .select(
+      'created_at, updated_at, id, isbn, rating, reading_start_at, reading_end_at, record_comment, like_count, user_id, users(nickname, profile_url), book!inner(thumbnail, isbn, title, authors, translators, publisher, datetime, contents)',
+      { count: 'exact' },
+    )
+    .eq('user_id', req.userId);
+
+  if (req.filter === 'ongoing') {
+    query = query
+      .is('rating', null)
+      .not('reading_start_at', 'is', null)
+      .is('reading_end_at', null)
+      .is('record_comment', null);
+  }
+
+  if (req.filter === 'completed') {
+    query = query
+      .not('rating', 'is', null)
+      .not('reading_start_at', 'is', null)
+      .not('reading_end_at', 'is', null)
+      .not('record_comment', 'is', null);
+  }
+
+  // NOTE: 페이징 적용
+  query = query.range(
+    (req.page - 1) * req.pageSize,
+    req.page * req.pageSize - 1,
+  );
+
+  // NOTE: 쿼리 실행
+  const {
+    data: records,
+    error: recordsError,
+    count: totalCount,
+  } = await query.returns<GetMyLibraryServerModel['records']>();
+
+  if (recordsError) {
+    throw new Error(recordsError.message);
+  }
+
+  return { records, totalCount };
+};

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -4,6 +4,8 @@ import type {
   CreateBookRecordQueryModel,
   CreateLikeForRecordQueryModel,
   DeleteLikeForRecordQueryModel,
+  GetBestRecordsQueryModel,
+  GetBestRecordsServerModel,
   GetBookRecordQueryModel,
   GetBookRecordServerModel,
   GetBookUserRecordsQueryModel,
@@ -191,4 +193,20 @@ export const deleteLikeForRecordAPI = async (
   if (error) {
     throw new Error(error.message);
   }
+};
+
+export const getBestRecordsAPI = async (req: GetBestRecordsQueryModel) => {
+  const { data, error } = await supabase
+    .rpc('get_best_record', {
+      startdatetime: req.startDateTime,
+      enddatetime: req.endDateTime,
+      limitcount: 10,
+    })
+    .returns<GetBestRecordsServerModel>();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data;
 };

--- a/src/components/atoms/card/book/list/BookListCard.tsx
+++ b/src/components/atoms/card/book/list/BookListCard.tsx
@@ -3,13 +3,12 @@ import { Link, useSearchParams } from 'react-router-dom';
 
 import { Button } from '@/components';
 import RatingIcon from '@/assets/icon/ic_rating.svg?react';
-// import { BOOK_READING_STATUS_OPTIONS } from '@/constants';
-// import type { SelectOptionType } from '@/types';
+import type { SelectOptionType } from '@/types';
 import * as S from './BookListCard.styled';
 
 interface BookListCardProps {
-  // readingStatus: SelectOptionType;
-  rating: number | null;
+  readingStatus?: SelectOptionType;
+  rating?: number | null;
   isbn: string;
   thumbnail: string;
   bookTitle: string;
@@ -22,7 +21,7 @@ interface BookListCardProps {
 
 const BookListCard = ({
   isbn,
-  // readingStatus,
+  readingStatus,
   rating,
   thumbnail,
   bookTitle,
@@ -44,12 +43,15 @@ const BookListCard = ({
   return (
     <Link css={S.bookDetailLink} key={isbn} to={`/book/${isbn}`}>
       <S.Header>
-        <S.ReadingStatus></S.ReadingStatus>
-        {/* <S.ReadingStatus>{readingStatus.label}</S.ReadingStatus> */}
-        <S.RatingWrapper>
-          <RatingIcon css={S.ratingIcon} />
-          <S.Rating>{rating ?? '-'} / 5</S.Rating>
-        </S.RatingWrapper>
+        {readingStatus && (
+          <S.ReadingStatus>{readingStatus.label}</S.ReadingStatus>
+        )}
+        {rating !== undefined && (
+          <S.RatingWrapper>
+            <RatingIcon css={S.ratingIcon} />
+            <S.Rating>{rating ?? '-'} / 5</S.Rating>
+          </S.RatingWrapper>
+        )}
       </S.Header>
       <S.Main>
         <S.BookThumbnail src={thumbnail} alt="book thumbnail" />

--- a/src/components/atoms/card/book/record/BookRecordCard.styled.ts
+++ b/src/components/atoms/card/book/record/BookRecordCard.styled.ts
@@ -8,11 +8,11 @@ export const bookRecordCard = css`
 
 export const BookCoverImg = tw.img`absolute left-[-20px] w-full max-w-[75px] h-full max-h-[116px] object-fill shadow-light_lg`;
 
-export const BookRecordInfo = tw.div`flex flex-col gap-y-[8px] flex-1 ml-[55px]`;
+export const BookRecordInfo = tw.div`flex flex-col gap-y-[8px] flex-1 w-[calc(100% - 55px)]  ml-[55px]`;
 
 export const Header = tw.div`flex items-center`;
 
-export const UserName = tw.span`flex-1 m-body-r14 text-left tablet:t-body-r14 desktop:d-body-r16`;
+export const UserName = tw.span`flex-1 m-body-r14 text-left text-ellipsis overflow-hidden tablet:t-body-r14 desktop:d-body-r16`;
 
 export const CreatedDate = tw.time`m-body-r12 text-gray600 mr-[4px] tablet:t-body-r12 desktop:d-body-r14`;
 

--- a/src/components/atoms/card/book/record/BookRecordCard.tsx
+++ b/src/components/atoms/card/book/record/BookRecordCard.tsx
@@ -1,43 +1,47 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
+import dayjs from 'dayjs';
 
 import { Profile } from '@/components';
 import { deviceState } from '@/stores';
 import LikeFillIcon from '@/assets/icon/ic_like_fill.svg?react';
-import type { BookRecordCardType } from '@/types';
+import type { GetBestRecordsServerModel } from '@/types';
 import * as S from './BookRecordCard.styled';
 
-interface BookRecordCardProps extends BookRecordCardType {
+type BookRecordCardProps = {
   linkToBaseUrl: string;
-}
+} & GetBestRecordsServerModel[number];
 
 const BookRecordCard = ({
   linkToBaseUrl,
-  id,
-  bookImgSrc,
-  profileImgSrc,
-  userName,
-  likeCount,
-  createdDate,
-  content,
+  created_at,
+  isbn,
+  record_comment,
+  like_count,
+  thumbnail,
+  nickname,
+  profile_url,
 }: BookRecordCardProps) => {
   const device = useRecoilValue(deviceState);
 
   return (
-    <Link css={S.bookRecordCard} to={`${linkToBaseUrl}/${id}`}>
-      <S.BookCoverImg src={bookImgSrc} />
+    // TODO: Link가 아니라 버튼 형태로 해서 모달 열어서 해당 감상문 기록을 자세히 볼 수 있도록 화면 수정 필요
+    <Link css={S.bookRecordCard} to={`${linkToBaseUrl}/${isbn}`}>
+      <S.BookCoverImg src={thumbnail} />
       <S.BookRecordInfo>
         <S.Header>
-          <Profile src={profileImgSrc} />
-          <S.UserName>{userName}</S.UserName>
-          <S.CreatedDate>{createdDate}</S.CreatedDate>
+          <Profile src={profile_url} />
+          <S.UserName>{nickname}</S.UserName>
+          <S.CreatedDate>
+            {dayjs(created_at).format('YYYY-MM-DD')}
+          </S.CreatedDate>
           <S.LikeWrapper>
             <LikeFillIcon css={S.likeIcon} />
-            <S.LikeCount>{likeCount}</S.LikeCount>
+            <S.LikeCount>{like_count}</S.LikeCount>
           </S.LikeWrapper>
         </S.Header>
-        <S.RecordContent device={device}>{content}</S.RecordContent>
+        <S.RecordContent device={device}>{record_comment}</S.RecordContent>
       </S.BookRecordInfo>
     </Link>
   );

--- a/src/components/composites/main/bestCommentary/BestCommentary.tsx
+++ b/src/components/composites/main/bestCommentary/BestCommentary.tsx
@@ -4,10 +4,10 @@ import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
 dayjs.extend(isoWeek);
 
+import { useGetBestRecords } from '@/services';
 import { deviceState } from '@/stores';
 import BestCommentaryMobile from './mobile/BestCommentaryMobile';
 import BestCommentaryDesktop from './desktop/BestCommentaryDesktop';
-import { useGetBestRecords } from '@/services';
 
 const BestCommentary = () => {
   const device = useRecoilValue(deviceState);

--- a/src/components/composites/main/bestCommentary/BestCommentary.tsx
+++ b/src/components/composites/main/bestCommentary/BestCommentary.tsx
@@ -1,76 +1,29 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
+import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+dayjs.extend(isoWeek);
 
 import { deviceState } from '@/stores';
-import Book1Img from '@/assets/image/book1.png';
-import Book2Img from '@/assets/image/book2.png';
-import Profile1Img from '@/assets/image/profile1.png';
-import Profile2Img from '@/assets/image/profile2.png';
-import type { BookRecordCardType } from '@/types';
 import BestCommentaryMobile from './mobile/BestCommentaryMobile';
 import BestCommentaryDesktop from './desktop/BestCommentaryDesktop';
+import { useGetBestRecords } from '@/services';
 
 const BestCommentary = () => {
   const device = useRecoilValue(deviceState);
-  // TODO: 더미용 데이터로 삭제 예정
-  const books: BookRecordCardType[] = [
-    {
-      id: '1',
-      bookImgSrc: Book1Img,
-      profileImgSrc: null,
-      userName: '홍길동',
-      likeCount: 14,
-      createdDate: '2024. 04. 01',
-      content:
-        'dsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjflj',
-    },
-    {
-      id: '2',
-      bookImgSrc: Book2Img,
-      profileImgSrc: Profile1Img,
-      userName: '김명석',
-      likeCount: 8,
-      createdDate: '2024. 03. 28',
-      content: 'dsfkldsjfldsj',
-    },
-    {
-      id: '3',
-      bookImgSrc: Book1Img,
-      profileImgSrc: Profile2Img,
-      userName: '박주영',
-      likeCount: 5,
-      createdDate: '2024. 03. 26',
-      content: 'dsfk 아ㅣㄴㅇ러ㅣㄴ아  ㅇㄴㅇㄹ안ㄹ ㅇㄴ리ㅏㅇ너',
-    },
-    {
-      id: '4',
-      bookImgSrc: Book1Img,
-      profileImgSrc: null,
-      userName: '홍길동',
-      likeCount: 14,
-      createdDate: '2024. 03. 30',
-      content:
-        'dsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjfljdsfkldsjfldsjfkldsjflj',
-    },
-    {
-      id: '5',
-      bookImgSrc: Book2Img,
-      profileImgSrc: Profile1Img,
-      userName: '김명석',
-      likeCount: 8,
-      createdDate: '2024. 04. 01',
-      content: 'dsfkldsjfldsj',
-    },
-    {
-      id: '6',
-      bookImgSrc: Book1Img,
-      profileImgSrc: Profile2Img,
-      userName: '박주영',
-      likeCount: 5,
-      createdDate: '2024. 03. 31',
-      content: 'dsfk 아ㅣㄴㅇ러ㅣㄴ아  ㅇㄴㅇㄹ안ㄹ ㅇㄴ리ㅏㅇ너',
-    },
-  ];
+
+  const today = dayjs();
+
+  // TODO: 추후 일간, 월간 들어갈지 말지 고려 필요
+  // TODO: 로그인하지 않았을 경우에 대한 화면 처리 필요
+  const req = {
+    startDateTime: today.isoWeekday(-6).startOf('day').toISOString(),
+    endDateTime: today.isoWeekday(0).startOf('day').toISOString(),
+  };
+
+  const { data: books } = useGetBestRecords(req);
+
+  if (!books) return null;
 
   return device === 'mobile' ? (
     <BestCommentaryMobile books={books} />

--- a/src/components/composites/main/bestCommentary/desktop/BestCommentaryDesktop.skeleton.tsx
+++ b/src/components/composites/main/bestCommentary/desktop/BestCommentaryDesktop.skeleton.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Skeleton from 'react-loading-skeleton';
+
+import * as S from './BestCommentaryDesktop.styled';
+
+const BestCommentaryDesktopSkeleton = () => {
+  return (
+    <S.BestCommentarySection>
+      <header>
+        <S.Title>주간 기록 베스트 10!</S.Title>
+      </header>
+      <S.BestCommentaryCardWrapper>
+        {Array.from({ length: 4 }, (_, i) => (
+          <Skeleton key={i} width={360} height={148} />
+        ))}
+      </S.BestCommentaryCardWrapper>
+    </S.BestCommentarySection>
+  );
+};
+
+export default BestCommentaryDesktopSkeleton;

--- a/src/components/composites/main/bestCommentary/desktop/BestCommentaryDesktop.styled.ts
+++ b/src/components/composites/main/bestCommentary/desktop/BestCommentaryDesktop.styled.ts
@@ -4,4 +4,4 @@ export const BestCommentarySection = tw.section`tablet:mb-[64px] mx-[64px] px-[2
 
 export const Title = tw.h2`tablet:t-body-m15 mb-[8px] desktop:d-body-m17`;
 
-export const BestCommentaryCardWrapper = tw.div`grid grid-cols-auto-fill-240 gap-x-[40px] gap-y-[20px]`;
+export const BestCommentaryCardWrapper = tw.div`grid grid-cols-auto-fill-308 gap-x-[40px] gap-y-[20px]`;

--- a/src/components/composites/main/bestCommentary/desktop/BestCommentaryDesktop.tsx
+++ b/src/components/composites/main/bestCommentary/desktop/BestCommentaryDesktop.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import { BookRecordCard } from '@/components';
-import type { BookRecordCardType } from '@/types';
+import type { GetBestRecordsServerModel } from '@/types';
 import * as S from './BestCommentaryDesktop.styled';
 
 interface BestCommentaryDesktopProps {
-  books: BookRecordCardType[];
+  books: GetBestRecordsServerModel;
 }
 
 const BestCommentaryDesktop = ({ books }: BestCommentaryDesktopProps) => {

--- a/src/components/composites/main/bestCommentary/index.ts
+++ b/src/components/composites/main/bestCommentary/index.ts
@@ -1,1 +1,3 @@
 export { default as BestCommentary } from './BestCommentary';
+export { default as BestCommentaryDesktopSkeleton } from './desktop/BestCommentaryDesktop.skeleton';
+export { default as BestCommentaryMobileSkeleton } from './mobile/BestCommentaryMobile.skeleton';

--- a/src/components/composites/main/bestCommentary/mobile/BestCommentaryMobile.skeleton.tsx
+++ b/src/components/composites/main/bestCommentary/mobile/BestCommentaryMobile.skeleton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Skeleton from 'react-loading-skeleton';
+
+import * as S from './BestCommentaryMobile.styled';
+
+const BestCommentaryMobileSkeleton = () => {
+  return (
+    <header>
+      <S.Title>주간 기록 베스트 10!</S.Title>
+      <S.SkeletonWrapper>
+        <Skeleton width="85%" height={148} />
+      </S.SkeletonWrapper>
+    </header>
+  );
+};
+
+export default BestCommentaryMobileSkeleton;

--- a/src/components/composites/main/bestCommentary/mobile/BestCommentaryMobile.styled.ts
+++ b/src/components/composites/main/bestCommentary/mobile/BestCommentaryMobile.styled.ts
@@ -1,5 +1,12 @@
-import tw from 'twin.macro';
+import tw, { css, styled } from 'twin.macro';
 
 export const Title = tw.h2`ml-[24px] mb-[8px] m-body-m15`;
 
 export const swiper = tw`pb-[10px]`;
+
+export const SkeletonWrapper = styled.div`
+  & > span {
+    display: flex;
+    justify-content: center;
+  }
+`;

--- a/src/components/composites/main/bestCommentary/mobile/BestCommentaryMobile.tsx
+++ b/src/components/composites/main/bestCommentary/mobile/BestCommentaryMobile.tsx
@@ -4,11 +4,11 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 
 import { BookRecordCard } from '@/components';
-import type { BookRecordCardType } from '@/types';
+import type { GetBestRecordsServerModel } from '@/types';
 import * as S from './BestCommentaryMobile.styled';
 
 interface BestCommentaryMobileProps {
-  books: BookRecordCardType[];
+  books: GetBestRecordsServerModel;
 }
 
 const BestCommentaryMobile = ({ books }: BestCommentaryMobileProps) => {

--- a/src/components/composites/myLibrary/MyLibraryPanel.tsx
+++ b/src/components/composites/myLibrary/MyLibraryPanel.tsx
@@ -1,89 +1,56 @@
 import React from 'react';
 
+import { useUser } from '@/contexts';
 import { BookListCard, NoData, Pagination } from '@/components';
-import Book1Img from '@/assets/image/book1.png';
-import Book2Img from '@/assets/image/book2.png';
+import { useGetMyLibraries } from '@/services';
+import { getBookReadingStatus } from '@/utils';
 import { BOOK_READING_STATUS_OPTIONS } from '@/constants';
-import type { GetMyLibraryServerModel } from '@/types';
 
 interface MyLibraryPanelProps {
-  queryStatus: (typeof BOOK_READING_STATUS_OPTIONS)[number]['key'] | 'all';
+  queryStatus: 'all' | 'ongoing' | 'completed';
 }
 
-// TODO: queryStatus 추후 사용
 const MyLibraryPanel = ({ queryStatus }: MyLibraryPanelProps) => {
-  const myLibraryServerData: GetMyLibraryServerModel = {
-    pageInfo: {
-      totalCount: 15,
-      totalPages: 2,
-    },
-    books: [
-      {
-        isbn: '234 263355',
-        readingStatus: 'completed',
-        rating: 4,
-        thumbnail: Book1Img,
-        bookTitle: '우아한 타입스크립트 with 리액트',
-        bookContent:
-          '주니어 프론트엔드 개발자를 위한 타입스크립트+리액트 온보딩 가이드 우아한형제들은 자바스크립트와 자체 개발 웹 프레임워크인 WoowahanJS를 사용했었다. 그러나 서비스가 대규모 웹 애플리케이션으로 성장하면서 기존 기술의 한계를 느끼고 타입스크립트와 리액트를 프론트엔드 표준 기술로 도입했다. 타입스크립트는 자바스크립트와 100% 호환되는 확장 언어로, 정적 타입을 지원하여 안정성과 유지보수성을 높여준다. 또한 객체 지향 프로그래밍을 지원하여 복잡한 애플리케이션을 개발하는 데 적합하다. 리액트는 UI를 개발하기 위한 라이브러리로 컴포넌트 기반의 개발 방식을 지원하여 코드의 재사용성과 유지보수성을 높여준다. 이 책은 우아한형제들의 실제 코드를 기반으로 타입스크립트의 기본 개념 및 특성과 리액트 환경에서의 타입스크립트 활용법을 알려준다. 또한 배달의민족 개발 사례와 우아한형제들 구성원의 인터뷰를 통해 실무에 바로 적용할 수 있는 다양한 기술 활용 팁을 소개한다.',
-        authors: ['기시미 이치로', '고가 후미타케'],
-        translators: ['전경아'],
-        publisher: '인플루엔셜',
-        datetime: '2014-11-17T00:00:00.000+09:00',
-      },
-      {
-        isbn: '234 263357',
-        readingStatus: 'ongoing',
-        rating: null,
-        thumbnail: Book2Img,
-        bookTitle: '우아한 타입스크립트 with 리액트',
-        bookContent:
-          '주니어 프론트엔드 개발자를 위한 타입스크립트+리액트 온보딩 가이드 우아한형제들은 자바스크립트와 자체 개발 웹 프레임워크인 WoowahanJS를 사용했었다. 그러나 서비스가 대규모 웹 애플리케이션으로 성장하면서 기존 기술의 한계를 느끼고 타입스크립트와 리액트를 프론트엔드 표준 기술로 도입했다. 타입스크립트는 자바스크립트와 100% 호환되는 확장 언어로, 정적 타입을 지원하여 안정성과 유지보수성을 높여준다. 또한 객체 지향 프로그래밍을 지원하여 복잡한 애플리케이션을 개발하는 데 적합하다. 리액트는 UI를 개발하기 위한 라이브러리로 컴포넌트 기반의 개발 방식을 지원하여 코드의 재사용성과 유지보수성을 높여준다. 이 책은 우아한형제들의 실제 코드를 기반으로 타입스크립트의 기본 개념 및 특성과 리액트 환경에서의 타입스크립트 활용법을 알려준다. 또한 배달의민족 개발 사례와 우아한형제들 구성원의 인터뷰를 통해 실무에 바로 적용할 수 있는 다양한 기술 활용 팁을 소개한다.',
-        authors: ['기시미 이치로', '고가 후미타케'],
-        translators: ['전경아'],
-        publisher: '인플루엔셜',
-        datetime: '2014-11-17T00:00:00.000+09:00',
-      },
-      {
-        isbn: '234 263358',
-        readingStatus: 'pending',
-        rating: null,
-        thumbnail: Book1Img,
-        bookTitle: '우아한 타입스크립트 with 리액트',
-        bookContent:
-          '주니어 프론트엔드 개발자를 위한 타입스크립트+리액트 온보딩 가이드 우아한형제들은 자바스크립트와 자체 개발 웹 프레임워크인 WoowahanJS를 사용했었다. 그러나 서비스가 대규모 웹 애플리케이션으로 성장하면서 기존 기술의 한계를 느끼고 타입스크립트와 리액트를 프론트엔드 표준 기술로 도입했다. 타입스크립트는 자바스크립트와 100% 호환되는 확장 언어로, 정적 타입을 지원하여 안정성과 유지보수성을 높여준다. 또한 객체 지향 프로그래밍을 지원하여 복잡한 애플리케이션을 개발하는 데 적합하다. 리액트는 UI를 개발하기 위한 라이브러리로 컴포넌트 기반의 개발 방식을 지원하여 코드의 재사용성과 유지보수성을 높여준다. 이 책은 우아한형제들의 실제 코드를 기반으로 타입스크립트의 기본 개념 및 특성과 리액트 환경에서의 타입스크립트 활용법을 알려준다. 또한 배달의민족 개발 사례와 우아한형제들 구성원의 인터뷰를 통해 실무에 바로 적용할 수 있는 다양한 기술 활용 팁을 소개한다.',
-        authors: ['기시미 이치로', '고가 후미타케'],
-        translators: ['전경아'],
-        publisher: '인플루엔셜',
-        datetime: '2014-11-17T00:00:00.000+09:00',
-      },
-    ],
+  const { user } = useUser();
+
+  const req = {
+    userId: user?.id!,
+    page: 1,
+    pageSize: 10,
+    filter: queryStatus,
   };
+
+  const { data } = useGetMyLibraries(req);
+
+  if (!data) return null;
 
   return (
     <div>
-      {myLibraryServerData.books.length ? (
-        myLibraryServerData.books.map((book) => (
+      {data.records.length ? (
+        data.records.map((record) => (
           <BookListCard
-            key={book.isbn}
-            readingStatus={book.readingStatus}
-            rating={book.rating}
-            isbn={book.isbn}
-            thumbnail={book.thumbnail}
-            bookTitle={book.bookTitle}
-            authors={book.authors}
-            translators={book.translators}
-            publisher={book.publisher}
-            datetime={book.datetime}
-            bookContent={book.bookContent}
+            key={record.book.isbn}
+            readingStatus={
+              getBookReadingStatus(
+                record.reading_start_at,
+                record.reading_end_at,
+              ) ?? BOOK_READING_STATUS_OPTIONS[0]
+            }
+            isbn={record.book.isbn}
+            thumbnail={record.book.thumbnail}
+            bookTitle={record.book.title}
+            authors={record.book.authors}
+            translators={record.book.translators}
+            publisher={record.book.publisher}
+            datetime={record.book.datetime}
+            bookContent={record.book.contents}
           />
         ))
       ) : (
         <NoData content={`비어 있습니다`} />
       )}
-
       <Pagination
-        totalPages={myLibraryServerData.pageInfo.totalPages}
+        totalPages={Math.ceil((data.totalCount ?? 0) / 10)}
         maxPageCount={10}
       />
     </div>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -22,6 +22,7 @@ export const AuthContextProvider = (props: any) => {
     supabase.auth.getSession().then(({ data: { session } }) => {
       setUserSession(session);
       setUser(session?.user ?? null);
+      setIsInitializing(false);
     });
 
     const { data: authListener } = supabase.auth.onAuthStateChange(
@@ -29,10 +30,9 @@ export const AuthContextProvider = (props: any) => {
         console.log(`Supabase auth event: ${e}`);
         setUserSession(session);
         setUser(session?.user ?? null);
+        setIsInitializing(false);
       },
     );
-
-    setIsInitializing(false);
 
     return () => {
       authListener.subscription.unsubscribe();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,19 +1,35 @@
-import React from 'react';
+import React, { Suspense } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import {
   BestCommentary,
   ReadingBook,
   MainLayout,
   PopularBook,
+  BestCommentaryMobileSkeleton,
+  BestCommentaryDesktopSkeleton,
 } from '@/components';
+import { deviceState } from '@/stores';
 import * as S from './index.styled';
 
 const root = () => {
+  const device = useRecoilValue(deviceState);
+
   return (
     <MainLayout css={S.mainLayout}>
       <ReadingBook />
       <PopularBook />
-      <BestCommentary />
+      <Suspense
+        fallback={
+          device === 'mobile' ? (
+            <BestCommentaryMobileSkeleton />
+          ) : (
+            <BestCommentaryDesktopSkeleton />
+          )
+        }
+      >
+        <BestCommentary />
+      </Suspense>
     </MainLayout>
   );
 };

--- a/src/pages/myLibrary/index.tsx
+++ b/src/pages/myLibrary/index.tsx
@@ -10,11 +10,12 @@ const root = () => {
       label: '전체',
       content: <MyLibraryPanel queryStatus="all" />,
     },
-    {
-      key: 'pending',
-      label: '소장 중',
-      content: <MyLibraryPanel queryStatus="pending" />,
-    },
+    // TODO: 소장 기능 추가 후 주석 해제
+    // {
+    //   key: 'pending',
+    //   label: '소장 중',
+    //   content: <MyLibraryPanel queryStatus="pending" />,
+    // },
     {
       key: 'ongoing',
       label: '읽고 있는 중',

--- a/src/pages/myLibrary/index.tsx
+++ b/src/pages/myLibrary/index.tsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 
-import { MainLayout, MyLibraryPanel, Tab } from '@/components';
+import {
+  BookListSkeleton,
+  MainLayout,
+  MyLibraryPanel,
+  Tab,
+} from '@/components';
 import * as S from './index.styled';
 
 const root = () => {
@@ -8,7 +13,11 @@ const root = () => {
     {
       key: 'all',
       label: '전체',
-      content: <MyLibraryPanel queryStatus="all" />,
+      content: (
+        <Suspense fallback={<BookListSkeleton />}>
+          <MyLibraryPanel queryStatus="all" />
+        </Suspense>
+      ),
     },
     // TODO: 소장 기능 추가 후 주석 해제
     // {
@@ -19,12 +28,20 @@ const root = () => {
     {
       key: 'ongoing',
       label: '읽고 있는 중',
-      content: <MyLibraryPanel queryStatus="ongoing" />,
+      content: (
+        <Suspense fallback={<BookListSkeleton />}>
+          <MyLibraryPanel queryStatus="ongoing" />
+        </Suspense>
+      ),
     },
     {
       key: 'completed',
       label: '읽기 완료',
-      content: <MyLibraryPanel queryStatus="completed" />,
+      content: (
+        <Suspense fallback={<BookListSkeleton />}>
+          <MyLibraryPanel queryStatus="completed" />
+        </Suspense>
+      ),
     },
   ];
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,5 @@
 export * from './auth';
 export * from './book';
+export * from './myLibrary';
 export * from './record';
 export { default as queryClient } from './queryClient';

--- a/src/services/myLibrary.ts
+++ b/src/services/myLibrary.ts
@@ -1,0 +1,17 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getMyLibrariesAPI } from '@/apis';
+import type { GetMyLibraryQueryModel } from '@/types';
+
+const myLibrary = {
+  all: ['myLibrary'] as const,
+  lists: () => [...myLibrary.all, 'list'] as const,
+  list: (req: GetMyLibraryQueryModel) => [...myLibrary.lists(), req] as const,
+};
+
+export const useGetMyLibraries = (req: GetMyLibraryQueryModel) => {
+  return useSuspenseQuery({
+    queryKey: myLibrary.list(req),
+    queryFn: () => getMyLibrariesAPI(req),
+  });
+};

--- a/src/services/record.ts
+++ b/src/services/record.ts
@@ -4,6 +4,7 @@ import {
   createBookRecordAPI,
   createLikeForRecordAPI,
   deleteLikeForRecordAPI,
+  getBestRecordsAPI,
   getBookRecordAPI,
   getBookUserRecordsAPI,
   getTotalLikeForRecordAPI,
@@ -13,6 +14,7 @@ import type {
   CreateBookRecordQueryModel,
   CreateLikeForRecordQueryModel,
   DeleteLikeForRecordQueryModel,
+  GetBestRecordsQueryModel,
   GetBookRecordQueryModel,
   GetBookUserRecordsQueryModel,
   GetTotalLikeForRecordQueryModel,
@@ -33,6 +35,7 @@ const bookRecordKeys = {
   },
   userRecordLike: (isbn: string, recordId: string) =>
     [...bookRecordKeys.userRecords(isbn), 'like', recordId] as const,
+  bestRecord: (req: GetBestRecordsQueryModel) => ['bestRecord', req] as const,
 };
 
 export const useGetBookRecord = (req: GetBookRecordQueryModel) => {
@@ -223,5 +226,12 @@ export const useDeleteLikeForRecord = () => {
         ),
       });
     },
+  });
+};
+
+export const useGetBestRecords = (req: GetBestRecordsQueryModel) => {
+  return useSuspenseQuery({
+    queryKey: bookRecordKeys.bestRecord(req),
+    queryFn: () => getBestRecordsAPI(req),
   });
 };

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -39,7 +39,7 @@ export interface GetBookDetailQueryModel {
   query: string;
 }
 
-interface Document {
+export interface Document {
   authors: string[];
   contents: string;
   datetime: string;
@@ -76,23 +76,4 @@ export interface GetBookDetailServerModel {
     total_count: number;
   };
   documents: Document[];
-}
-
-export interface GetMyLibraryServerModel {
-  pageInfo: {
-    totalCount: number;
-    totalPages: number;
-  };
-  books: {
-    isbn: string;
-    readingStatus: (typeof BOOK_READING_STATUS_OPTIONS)[number]['key'];
-    rating: number | null;
-    thumbnail: string;
-    bookTitle: string;
-    bookContent: string;
-    authors: string[];
-    translators: string[];
-    datetime: string;
-    publisher: string;
-  }[];
 }

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -1,15 +1,3 @@
-import { BOOK_READING_STATUS_OPTIONS } from '@/constants';
-
-export interface BookRecordCardType {
-  id: string;
-  bookImgSrc: string;
-  profileImgSrc: string | null;
-  userName: string;
-  likeCount: number;
-  createdDate: string;
-  content: string;
-}
-
 export interface ReadingBookCardType {
   id: string;
   bookImgSrc: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from './auth';
 export * from './book';
 export * from './common';
+export * from './myLibrary';
 export * from './record';

--- a/src/types/myLibrary.ts
+++ b/src/types/myLibrary.ts
@@ -1,0 +1,17 @@
+import type { Document } from './book';
+import type { BookRecordServerData } from './record';
+
+export interface GetMyLibraryQueryModel {
+  userId: string;
+  page: number;
+  pageSize: number;
+  filter: 'all' | 'ongoing' | 'completed';
+}
+
+export interface GetMyLibraryServerModel {
+  records: (BookRecordServerData & {
+    book: Document;
+    users: { nickname: string; profile_url: string | null };
+  })[];
+  totalCount: number;
+}

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -71,3 +71,23 @@ export interface DeleteLikeForRecordQueryModel {
   userId: string;
   recordId: string;
 }
+
+export interface GetBestRecordsQueryModel {
+  startDateTime: string;
+  endDateTime: string;
+}
+
+export type GetBestRecordsServerModel = {
+  created_at: string;
+  updated_at: string;
+  id: string;
+  isbn: string;
+  rating: number;
+  reading_start_at: string;
+  reading_end_at: string;
+  record_comment: string;
+  like_count: number;
+  thumbnail: string;
+  nickname: string;
+  profile_url: string | null;
+}[];

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -5,7 +5,7 @@ export interface GetBookRecordQueryModel {
   isbn: string;
 }
 
-type BookRecordServerData = {
+export type BookRecordServerData = {
   created_at: string;
   updated_at: string;
   id: string;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -113,7 +113,7 @@ export default {
       gridTemplateColumns: {
         'auto-fill-144': 'repeat(auto-fill, minmax(144px, 1fr))',
         'auto-fill-192': 'repeat(auto-fill, minmax(192px, 1fr))',
-        'auto-fill-240': 'repeat(auto-fill, minmax(240px, 1fr))',
+        'auto-fill-308': 'repeat(auto-fill, minmax(308px, 1fr))',
       },
       backgroundImage: {
         check: `url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e")`,


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature -> main

### 변경 사항
1. 기능 추가
   a. 독서 기록 ('전체', '읽는 중', '읽기 완료') 상태에 따른 조회 기능 구현
   b. 메인 화면 內 주간 베스트 독서 감상문 조회 기능 구현

2. 이슈 수정
   a. 독서 목록 평점 조회 시 (현재: isbn 10자리) 원본(isbn 10자리 13자리) 사용하도록 수정
   b. Auth 관련하여 `isInitializing` ture, `user` null -> isInitializing` false -> `user` object 
      되는 이슈가 있어 독서 목록 화면에서 로그인했는데도 불구하고 로그인 페이지로 리다이렉트 되어
      로직 수정 (f0d20f08b192c251eb1397674c4fd4e47644741e)


3. 스크린 추가
   a. 독서 기록 조회 스켈레톤 UI 제작
   b. 주간 베스트 독서 감상문 스켈레톤 UI 제작


### 참고 사항
