### PR TITLE
현재 읽고 있는 책 조회 API 연동

### DIFF
--- a/src/apis/myLibrary.ts
+++ b/src/apis/myLibrary.ts
@@ -28,11 +28,13 @@ export const getMyLibrariesAPI = async (req: GetMyLibraryQueryModel) => {
       .not('record_comment', 'is', null);
   }
 
-  // NOTE: 페이징 적용
-  query = query.range(
-    (req.page - 1) * req.pageSize,
-    req.page * req.pageSize - 1,
-  );
+  // NOTE: 독서 기록 페이지에서는 페이징 적용하나, 메인 화면의 현재 읽고 있는 책 조회 시에는 페이징 적용 X
+  if (req.page && req.pageSize) {
+    query = query.range(
+      (req.page - 1) * req.pageSize,
+      req.page * req.pageSize - 1,
+    );
+  }
 
   // NOTE: 쿼리 실행
   const {

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -152,14 +152,7 @@ export const getTotalLikeForRecordAPI = async (
       input_record_id: req.recordId,
       input_user_id: req.userId,
     })
-    .returns<
-      [
-        {
-          isliked: GetTotalLikeForRecordServerModel['isliked'];
-          count: GetTotalLikeForRecordServerModel['count'];
-        },
-      ]
-    >();
+    .returns<[GetTotalLikeForRecordServerModel]>();
 
   if (error) {
     throw new Error(error.message);
@@ -198,6 +191,7 @@ export const deleteLikeForRecordAPI = async (
 export const getBestRecordsAPI = async (req: GetBestRecordsQueryModel) => {
   const { data, error } = await supabase
     .rpc('get_best_record', {
+      current_user_id: req.userId,
       startdatetime: req.startDateTime,
       enddatetime: req.endDateTime,
       limitcount: 10,

--- a/src/components/atoms/button/index.ts
+++ b/src/components/atoms/button/index.ts
@@ -1,2 +1,3 @@
 export { default as Button } from './Button';
+export { default as LikeButton } from './like/LikeButton';
 export { default as SegmentedButton } from './segmented/SegmentedButton';

--- a/src/components/atoms/button/like/LikeButton.styled.ts
+++ b/src/components/atoms/button/like/LikeButton.styled.ts
@@ -1,0 +1,13 @@
+import tw, { css } from 'twin.macro';
+
+export const LikeButton = tw.button`flex items-center gap-[4px]`;
+
+export const likeIcon = css`
+  ${tw`w-[16px] h-[16px]`}
+
+  & > g > path {
+    ${tw`fill-blue200`}
+  }
+`;
+
+export const Like = tw.span`m-body-m13 tablet:t-body-m13 desktop:d-body-m15`;

--- a/src/components/atoms/button/like/LikeButton.styled.ts
+++ b/src/components/atoms/button/like/LikeButton.styled.ts
@@ -1,6 +1,8 @@
-import tw, { css } from 'twin.macro';
+import tw, { css, styled } from 'twin.macro';
 
-export const LikeButton = tw.button`flex items-center gap-[4px]`;
+export const LikeButton = styled.button`
+  ${tw`flex items-center gap-[4px]`}
+`;
 
 export const likeIcon = css`
   ${tw`w-[16px] h-[16px]`}

--- a/src/components/atoms/button/like/LikeButton.tsx
+++ b/src/components/atoms/button/like/LikeButton.tsx
@@ -11,12 +11,18 @@ import LikeFilledIcon from '@/assets/icon/ic_thumb_up_filled.svg?react';
 import * as S from './LikeButton.styled';
 
 interface LikeButtonProps {
+  as?: 'div' | 'button';
   isbn: string;
   recordId: string;
   userId: string;
 }
 
-const LikeButton = ({ isbn, recordId, userId }: LikeButtonProps) => {
+const LikeButton = ({
+  as = 'button',
+  isbn,
+  recordId,
+  userId,
+}: LikeButtonProps) => {
   const { user } = useUser();
   const currentUserId = user?.id!;
 
@@ -36,6 +42,9 @@ const LikeButton = ({ isbn, recordId, userId }: LikeButtonProps) => {
 
   return (
     <S.LikeButton
+      as={as}
+      role="button"
+      tabIndex={0}
       disabled={currentUserId === userId}
       type="button"
       onClick={handleLikeButtonClick(isbn, recordId, currentUserId)}

--- a/src/components/atoms/button/like/LikeButton.tsx
+++ b/src/components/atoms/button/like/LikeButton.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { useUser } from '@/contexts';
+import {
+  useCreateLikeForRecord,
+  useDeleteLikeForRecord,
+  useGetTotalLikeForRecord,
+} from '@/services';
+import LikeIcon from '@/assets/icon/ic_thumb_up.svg?react';
+import LikeFilledIcon from '@/assets/icon/ic_thumb_up_filled.svg?react';
+import * as S from './LikeButton.styled';
+
+interface LikeButtonProps {
+  isbn: string;
+  recordId: string;
+  userId: string;
+}
+
+const LikeButton = ({ isbn, recordId, userId }: LikeButtonProps) => {
+  const { user } = useUser();
+  const currentUserId = user?.id!;
+
+  const req = { isbn, userId: currentUserId, recordId };
+  const { data } = useGetTotalLikeForRecord(req);
+  const { mutate: createLikeRecord } = useCreateLikeForRecord();
+  const { mutate: deleteLikeRecord } = useDeleteLikeForRecord();
+
+  const handleLikeButtonClick =
+    (isbn: string, recordId: string, userId: string) =>
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+
+      const req = { recordId, userId, isbn };
+      data[0].isliked ? deleteLikeRecord(req) : createLikeRecord(req);
+    };
+
+  return (
+    <S.LikeButton
+      disabled={currentUserId === userId}
+      type="button"
+      onClick={handleLikeButtonClick(isbn, recordId, currentUserId)}
+    >
+      {data[0].isliked ? (
+        <LikeFilledIcon css={S.likeIcon} />
+      ) : (
+        <LikeIcon css={S.likeIcon} />
+      )}
+      <S.Like>{data[0].count}</S.Like>
+    </S.LikeButton>
+  );
+};
+
+export default LikeButton;

--- a/src/components/atoms/card/book/index.ts
+++ b/src/components/atoms/card/book/index.ts
@@ -1,3 +1,4 @@
 export * from './list';
 export { default as BookReadingCard } from './reading/BookReadingCard';
+export { default as BookReadingCardSkeleton } from './reading/BookReadingCard.skeleton';
 export { default as BookRecordCard } from './record/BookRecordCard';

--- a/src/components/atoms/card/book/reading/BookReadingCard.skeleton.tsx
+++ b/src/components/atoms/card/book/reading/BookReadingCard.skeleton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Skeleton from 'react-loading-skeleton';
+
+import * as S from './BookReadingCard.styled';
+
+interface BookReadingCardSkeletonProps {
+  className?: string;
+}
+
+const BookReadingCardSkeleton = ({
+  className,
+}: BookReadingCardSkeletonProps) => {
+  return (
+    <S.SkeletonCard className={className}>
+      <Skeleton css={S.bookTitleSkeleton} width={100} height={22} />
+      <S.BookDescriptionWrapper>
+        <Skeleton css={S.bookThumbnailSkeleton} width={75} height={116} />
+        <S.BookContentWrapper>
+          <Skeleton width={82} height={17} />
+          <Skeleton width={45} height={17} />
+          <Skeleton width={77} height={16} />
+        </S.BookContentWrapper>
+      </S.BookDescriptionWrapper>
+    </S.SkeletonCard>
+  );
+};
+
+export default BookReadingCardSkeleton;

--- a/src/components/atoms/card/book/reading/BookReadingCard.styled.ts
+++ b/src/components/atoms/card/book/reading/BookReadingCard.styled.ts
@@ -1,6 +1,17 @@
-import tw, { styled } from 'twin.macro';
+import tw, { css, styled } from 'twin.macro';
 
-export const CardButton = tw.button`flex flex-col rounded-[4px] p-[16px] w-[186px] h-[207px] bg-white shadow-light_md hover:bg-brown50`;
+export const defaultCard = css`
+  ${tw`flex flex-col rounded-[4px] p-[16px] w-[186px] h-[207px] bg-white shadow-light_md`}
+`;
+
+export const SkeletonCard = styled.div`
+  ${defaultCard}
+`;
+
+export const CardButton = styled.button`
+  ${defaultCard}
+  ${tw`hover:bg-brown50`}
+`;
 
 export const BookTitle = styled.span`
   ${tw`h-[55px] m-body-m14 text-ellipsis break-all overflow-hidden`}
@@ -10,9 +21,19 @@ export const BookTitle = styled.span`
   -webkit-box-orient: vertical;
 `;
 
+export const bookTitleSkeleton = css`
+  ${tw`mb-[23px]`}
+`;
+
 export const BookDescriptionWrapper = tw.div`relative flex-1 mt-[4px] w-full`;
 
-export const BookThumbnail = tw.img`absolute left-[-32px] w-full max-w-[75px] h-full max-h-[116px] object-fill shadow-light_lg`;
+export const bookThumbnailSkeleton = css`
+  ${tw`absolute left-[-32px] w-full max-w-[75px] h-full max-h-[116px] object-fill shadow-light_lg`}
+`;
+
+export const BookThumbnail = styled.img`
+  ${bookThumbnailSkeleton};
+`;
 
 export const BookContentWrapper = tw.div`flex flex-col items-start gap-y-[4px] ml-[51px]`;
 

--- a/src/components/atoms/card/book/reading/BookReadingCard.tsx
+++ b/src/components/atoms/card/book/reading/BookReadingCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import dayjs from 'dayjs';
 
 import type { GetMyLibraryServerModel } from '@/types';
@@ -21,13 +22,22 @@ interface BookReadingCardProps {
 
 const BookReadingCard = ({
   className,
-  isbn, // TODO: isbn 추후 활용
+  isbn,
   book,
   reading_start_at,
 }: BookReadingCardProps) => {
+  const navigate = useNavigate();
+
+  const handleButtonClick = (isbn: string) => () => {
+    navigate(`book/${isbn}`);
+  };
+
   return (
-    // TODO: 클릭 이벤트 추가 예정
-    <S.CardButton className={className} type="button" onClick={() => {}}>
+    <S.CardButton
+      className={className}
+      type="button"
+      onClick={handleButtonClick(isbn)}
+    >
       <S.BookTitle>{book.title}</S.BookTitle>
       <S.BookDescriptionWrapper>
         <S.BookThumbnail src={book.thumbnail} alt="book thumbnail" />

--- a/src/components/atoms/card/book/reading/BookReadingCard.tsx
+++ b/src/components/atoms/card/book/reading/BookReadingCard.tsx
@@ -1,36 +1,42 @@
 import React from 'react';
+import dayjs from 'dayjs';
 
+import type { GetMyLibraryServerModel } from '@/types';
 import * as S from './BookReadingCard.styled';
 
 interface BookReadingCardProps {
   className?: string;
   id: string;
-  bookImgSrc: string;
-  title: string;
-  publisher: string;
-  authors: string[];
-  readingStartDate: string;
+  book: GetMyLibraryServerModel['records'][number]['book'];
+  isbn: string;
+  reading_start_at: string | null;
+  reading_end_at: string | null;
+  rating: number | null;
+  like_count: number;
+  created_at: string;
+  updated_at: string;
+  user_id: string;
+  users: GetMyLibraryServerModel['records'][number]['users'];
 }
 
 const BookReadingCard = ({
   className,
-  id, // TODO: id 추후 활용
-  bookImgSrc,
-  title,
-  publisher,
-  authors,
-  readingStartDate,
+  isbn, // TODO: isbn 추후 활용
+  book,
+  reading_start_at,
 }: BookReadingCardProps) => {
   return (
     // TODO: 클릭 이벤트 추가 예정
     <S.CardButton className={className} type="button" onClick={() => {}}>
-      <S.BookTitle>{title}</S.BookTitle>
+      <S.BookTitle>{book.title}</S.BookTitle>
       <S.BookDescriptionWrapper>
-        <S.BookThumbnail src={bookImgSrc} alt="book thumbnail" />
+        <S.BookThumbnail src={book.thumbnail} alt="book thumbnail" />
         <S.BookContentWrapper>
-          <S.Author>{authors.join(', ')}</S.Author>
-          <S.publisher>{publisher}</S.publisher>
-          <S.Date>{readingStartDate}</S.Date>
+          <S.Author>{book.authors.join(', ')}</S.Author>
+          <S.publisher>{book.publisher}</S.publisher>
+          {reading_start_at && (
+            <S.Date>{dayjs(reading_start_at).format('YYYY-MM-DD')} ~</S.Date>
+          )}
         </S.BookContentWrapper>
       </S.BookDescriptionWrapper>
     </S.CardButton>

--- a/src/components/atoms/card/book/record/BookRecordCard.styled.ts
+++ b/src/components/atoms/card/book/record/BookRecordCard.styled.ts
@@ -3,7 +3,7 @@ import tw, { css, styled } from 'twin.macro';
 import type { DeviceType } from '@/types';
 
 export const bookRecordCard = css`
-  ${tw` relative flex gap-x-[19px] min-w-[208px] h-[148px] rounded-[4px] px-[12px] py-[18px] bg-white shadow-light_md hover:bg-brown50`}
+  ${tw`relative flex gap-x-[19px] min-w-[208px] w-full h-[148px] rounded-[4px] px-[12px] py-[18px] bg-white shadow-light_md hover:bg-brown50`}
 `;
 
 export const BookCoverImg = tw.img`absolute left-[-20px] w-full max-w-[75px] h-full max-h-[116px] object-fill shadow-light_lg`;
@@ -12,21 +12,9 @@ export const BookRecordInfo = tw.div`flex flex-col gap-y-[8px] flex-1 w-[calc(10
 
 export const Header = tw.div`flex items-center`;
 
-export const UserName = tw.span`flex-1 m-body-r14 text-left text-ellipsis overflow-hidden tablet:t-body-r14 desktop:d-body-r16`;
+export const UserName = tw.span`flex-1 m-body-r14 text-left text-ellipsis overflow-hidden whitespace-nowrap tablet:t-body-r14 desktop:d-body-r16`;
 
 export const CreatedDate = tw.time`m-body-r12 text-gray600 mr-[4px] tablet:t-body-r12 desktop:d-body-r14`;
-
-export const LikeWrapper = tw.div`flex items-center gap-x-[2px]`;
-
-export const likeIcon = css`
-  ${tw`w-[16px] h-[16px]`}
-
-  & > g > path {
-    ${tw`fill-red200`}
-  }
-`;
-
-export const LikeCount = tw.span`m-caption-r12 tablet:t-caption-r12 desktop:d-caption-r12`;
 
 export const RecordContent = styled.p<{ device: DeviceType }>`
   ${({ device }) => css`

--- a/src/components/atoms/card/book/record/BookRecordCard.tsx
+++ b/src/components/atoms/card/book/record/BookRecordCard.tsx
@@ -42,6 +42,7 @@ const BookRecordCard = ({ bookRecord }: BookRecordCardProps) => {
             {dayjs(bookRecord.created_at).format('YYYY-MM-DD')}
           </S.CreatedDate>
           <LikeButton
+            as="div"
             isbn={bookRecord.isbn}
             recordId={bookRecord.id}
             userId={bookRecord.user_id}

--- a/src/components/atoms/card/book/record/BookRecordCard.tsx
+++ b/src/components/atoms/card/book/record/BookRecordCard.tsx
@@ -1,49 +1,57 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import dayjs from 'dayjs';
 
-import { Profile } from '@/components';
+import { LikeButton, Profile } from '@/components';
+import { useModal } from '@/hooks';
 import { deviceState } from '@/stores';
-import LikeFillIcon from '@/assets/icon/ic_like_fill.svg?react';
 import type { GetBestRecordsServerModel } from '@/types';
+import BookRecordDetailModal from './modal/BookRecordDetailModal';
 import * as S from './BookRecordCard.styled';
 
-type BookRecordCardProps = {
-  linkToBaseUrl: string;
-} & GetBestRecordsServerModel[number];
+interface BookRecordCardProps {
+  bookRecord: GetBestRecordsServerModel[number];
+}
 
-const BookRecordCard = ({
-  linkToBaseUrl,
-  created_at,
-  isbn,
-  record_comment,
-  like_count,
-  thumbnail,
-  nickname,
-  profile_url,
-}: BookRecordCardProps) => {
+const BookRecordCard = ({ bookRecord }: BookRecordCardProps) => {
+  const navigate = useNavigate();
+
   const device = useRecoilValue(deviceState);
 
+  const { modalRef, openModal } = useModal();
+
   return (
-    // TODO: Link가 아니라 버튼 형태로 해서 모달 열어서 해당 감상문 기록을 자세히 볼 수 있도록 화면 수정 필요
-    <Link css={S.bookRecordCard} to={`${linkToBaseUrl}/${isbn}`}>
-      <S.BookCoverImg src={thumbnail} />
+    <button
+      type="button"
+      css={S.bookRecordCard}
+      onClick={openModal(
+        <BookRecordDetailModal
+          ref={modalRef}
+          bookRecord={bookRecord}
+          navigate={navigate}
+        />,
+      )}
+    >
+      <S.BookCoverImg src={bookRecord.thumbnail} />
       <S.BookRecordInfo>
         <S.Header>
-          <Profile src={profile_url} />
-          <S.UserName>{nickname}</S.UserName>
+          <Profile src={bookRecord.profile_url} />
+          <S.UserName>{bookRecord.nickname}</S.UserName>
           <S.CreatedDate>
-            {dayjs(created_at).format('YYYY-MM-DD')}
+            {dayjs(bookRecord.created_at).format('YYYY-MM-DD')}
           </S.CreatedDate>
-          <S.LikeWrapper>
-            <LikeFillIcon css={S.likeIcon} />
-            <S.LikeCount>{like_count}</S.LikeCount>
-          </S.LikeWrapper>
+          <LikeButton
+            isbn={bookRecord.isbn}
+            recordId={bookRecord.id}
+            userId={bookRecord.user_id}
+          />
         </S.Header>
-        <S.RecordContent device={device}>{record_comment}</S.RecordContent>
+        <S.RecordContent device={device}>
+          {bookRecord.record_comment}
+        </S.RecordContent>
       </S.BookRecordInfo>
-    </Link>
+    </button>
   );
 };
 

--- a/src/components/atoms/card/book/record/modal/BookRecordDetailModal.styled.ts
+++ b/src/components/atoms/card/book/record/modal/BookRecordDetailModal.styled.ts
@@ -1,0 +1,19 @@
+import tw from 'twin.macro';
+
+export const Container = tw.div`flex gap-x-[12px] tablet:gap-x-[16px] desktop:gap-x-[24px]`;
+
+export const BookContentWrapper = tw.div`self-center flex flex-col gap-y-[4px]`;
+
+export const BookCoverImg = tw.img`max-w-[75px] h-full max-h-[116px] object-fill tablet:(max-w-[100px] max-h-[155px]) desktop:(max-w-[125px] max-h-[193px])`;
+
+export const UserInfoWrapper = tw.div`flex items-center`;
+
+export const UserName = tw.span`flex-1 m-body-r14 text-left text-ellipsis overflow-hidden tablet:t-body-r14 desktop:d-body-r16`;
+
+export const CreatedDate = tw.time`m-body-r12 text-gray600 mr-[4px] tablet:t-body-r12 desktop:d-body-r14`;
+
+export const ContentWrapper = tw.div`flex flex-col gap-y-[4px]`;
+
+export const RecordContent = tw.p`m-body-r12 text-left text-ellipsis break-all overflow-hidden tablet:t-body-r14 desktop:d-body-r14`;
+
+export const BottomWrapper = tw.div`flex justify-between gap-x-[4px] w-full`;

--- a/src/components/atoms/card/book/record/modal/BookRecordDetailModal.tsx
+++ b/src/components/atoms/card/book/record/modal/BookRecordDetailModal.tsx
@@ -1,0 +1,84 @@
+import React, { Suspense } from 'react';
+import type { NavigateFunction } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import dayjs from 'dayjs';
+import Skeleton from 'react-loading-skeleton';
+
+import { Button, LikeButton, Modal, Profile } from '@/components';
+import { useModal } from '@/hooks';
+import { deviceState } from '@/stores';
+import type { GetBestRecordsServerModel } from '@/types';
+import * as S from './BookRecordDetailModal.styled';
+
+interface BookRecordDetailModalProps {
+  bookRecord: GetBestRecordsServerModel[number];
+  navigate: NavigateFunction;
+}
+
+const BookRecordDetailModal = React.forwardRef<
+  HTMLDialogElement,
+  BookRecordDetailModalProps
+>(({ bookRecord, navigate }, ref) => {
+  const device = useRecoilValue(deviceState);
+
+  const { closeModal } = useModal();
+
+  const handleButtonClick = (isbn: string) => () => {
+    navigate(`book/${isbn}`);
+    closeModal();
+  };
+
+  return (
+    <Modal
+      ref={ref}
+      title="독서 기록 상세"
+      closeButtonName="닫기"
+      closeFn={closeModal}
+    >
+      <S.Container>
+        {device !== 'mobile' && (
+          <S.BookContentWrapper>
+            <S.BookCoverImg src={bookRecord.thumbnail} alt="도서 썸네일" />
+            <Button
+              label="상세화면 보기"
+              sizeType="sm"
+              styleType="tertiary"
+              onClick={handleButtonClick(bookRecord.isbn)}
+            />
+          </S.BookContentWrapper>
+        )}
+        <S.ContentWrapper>
+          <S.UserInfoWrapper>
+            <Profile src={bookRecord.profile_url} />
+            <S.UserName>{bookRecord.nickname}</S.UserName>
+            <S.CreatedDate>
+              {dayjs(bookRecord.created_at).format('YYYY-MM-DD')}
+            </S.CreatedDate>
+          </S.UserInfoWrapper>
+          <S.RecordContent>{bookRecord.record_comment}</S.RecordContent>
+          <S.BottomWrapper>
+            {device === 'mobile' && (
+              <Button
+                label="상세화면 보기"
+                sizeType="sm"
+                styleType="tertiary"
+                onClick={handleButtonClick(bookRecord.isbn)}
+              />
+            )}
+            <Suspense fallback={<Skeleton width={30} height={17} />}>
+              <LikeButton
+                isbn={bookRecord.isbn}
+                recordId={bookRecord.id}
+                userId={bookRecord.user_id}
+              />
+            </Suspense>
+          </S.BottomWrapper>
+        </S.ContentWrapper>
+      </S.Container>
+    </Modal>
+  );
+});
+
+export default BookRecordDetailModal;
+
+BookRecordDetailModal.displayName = 'BookRecordDetailModal';

--- a/src/components/atoms/link/bookAdd/BookAddLink.tsx
+++ b/src/components/atoms/link/bookAdd/BookAddLink.tsx
@@ -6,11 +6,10 @@ import * as S from './BookAddLink.styled';
 
 const BookAddLink = () => {
   return (
-    // TODO: 하이퍼 링크 고민 후 수정 예정
-    <Link css={S.bookAddLink} to="/addBook">
+    <Link css={S.bookAddLink} to="/book">
       <AddIcon css={S.addIcon} />
       <S.MainDescription>현재 읽고 있는 책이 없습니다.</S.MainDescription>
-      <S.SubDescription>책을 추가하시겠습니까?</S.SubDescription>
+      <S.SubDescription>책을 검색하여 추가해주세요.</S.SubDescription>
     </Link>
   );
 };

--- a/src/components/composites/book/detail/record/list/item/BookRecordListItem.skeleton.tsx
+++ b/src/components/composites/book/detail/record/list/item/BookRecordListItem.skeleton.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Skeleton from 'react-loading-skeleton';
 
-import LikeIcon from '@/assets/icon/ic_thumb_up.svg?react';
 import * as S from './BookRecordListItem.styled';
 
 const BookRecordListItemSkeleton = () => {
@@ -21,12 +20,7 @@ const BookRecordListItemSkeleton = () => {
         <Skeleton width="100%" height={48} />
       </S.RecordItemContent>
       <S.RecordItemFooter>
-        <S.LikeButton type="button" onClick={() => {}}>
-          <LikeIcon css={S.likeIcon} />
-          <S.Like>
-            <Skeleton width={16} />
-          </S.Like>
-        </S.LikeButton>
+        <Skeleton width={30} height={17} />
       </S.RecordItemFooter>
     </S.RecordItemContainer>
   );

--- a/src/components/composites/book/detail/record/list/item/BookRecordListItem.styled.ts
+++ b/src/components/composites/book/detail/record/list/item/BookRecordListItem.styled.ts
@@ -24,15 +24,3 @@ export const ratingIcon = (isFilled: boolean) => css`
 export const RecordItemContent = tw.p`m-body-r14 tablet:t-body-r14 desktop:d-body-r16`;
 
 export const RecordItemFooter = tw.footer`flex justify-end w-full`;
-
-export const LikeButton = tw.button`flex items-center gap-[4px]`;
-
-export const likeIcon = css`
-  ${tw`w-[16px] h-[16px]`}
-
-  & > g > path {
-    ${tw`fill-blue200`}
-  }
-`;
-
-export const Like = tw.span`m-body-m13 tablet:t-body-m13 desktop:d-body-m15`;

--- a/src/components/composites/book/detail/record/list/item/BookRecordListItem.tsx
+++ b/src/components/composites/book/detail/record/list/item/BookRecordListItem.tsx
@@ -1,16 +1,6 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
 
-import { useUser } from '@/contexts';
-import { Profile } from '@/components';
-import {
-  useCreateLikeForRecord,
-  useDeleteLikeForRecord,
-  useGetTotalLikeForRecord,
-} from '@/services';
-import { getFirstIsbnSegment } from '@/utils';
-import LikeIcon from '@/assets/icon/ic_thumb_up.svg?react';
-import LikeFilledIcon from '@/assets/icon/ic_thumb_up_filled.svg?react';
+import { LikeButton, Profile } from '@/components';
 import RatingIcon from '@/assets/icon/ic_rating.svg?react';
 import type { GetBookUserRecordsServerModel } from '@/types';
 import * as S from './BookRecordListItem.styled';
@@ -20,23 +10,6 @@ interface BookRecordListItemProps {
 }
 
 const BookRecordListItem = ({ record }: BookRecordListItemProps) => {
-  const { id } = useParams();
-
-  const { user } = useUser();
-  const isbn = getFirstIsbnSegment(id);
-  const userId = user?.id!;
-  const req = { isbn, userId, recordId: record.id };
-
-  const { data } = useGetTotalLikeForRecord(req);
-  const { mutate: createLikeRecord } = useCreateLikeForRecord();
-  const { mutate: deleteLikeRecord } = useDeleteLikeForRecord();
-
-  const handleLikeButtonClick = (recordId: string) => () => {
-    const req = { recordId, userId, isbn };
-
-    data[0].isliked ? deleteLikeRecord(req) : createLikeRecord(req);
-  };
-
   return (
     <S.RecordItemContainer key={record.id}>
       <S.RecordItemHeader>
@@ -53,18 +26,11 @@ const BookRecordListItem = ({ record }: BookRecordListItemProps) => {
       </S.RecordItemHeader>
       <S.RecordItemContent>{record.record_comment}</S.RecordItemContent>
       <S.RecordItemFooter>
-        <S.LikeButton
-          disabled={userId === record.user_id}
-          type="button"
-          onClick={handleLikeButtonClick(record.id)}
-        >
-          {data[0].isliked ? (
-            <LikeFilledIcon css={S.likeIcon} />
-          ) : (
-            <LikeIcon css={S.likeIcon} />
-          )}
-          <S.Like>{data[0].count}</S.Like>
-        </S.LikeButton>
+        <LikeButton
+          isbn={record.isbn}
+          recordId={record.id}
+          userId={record.user_id}
+        />
       </S.RecordItemFooter>
     </S.RecordItemContainer>
   );

--- a/src/components/composites/main/bestCommentary/BestCommentary.tsx
+++ b/src/components/composites/main/bestCommentary/BestCommentary.tsx
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
 dayjs.extend(isoWeek);
 
+import { useUser } from '@/contexts';
 import { useGetBestRecords } from '@/services';
 import { deviceState } from '@/stores';
 import BestCommentaryMobile from './mobile/BestCommentaryMobile';
@@ -12,18 +13,17 @@ import BestCommentaryDesktop from './desktop/BestCommentaryDesktop';
 const BestCommentary = () => {
   const device = useRecoilValue(deviceState);
 
+  const { user } = useUser();
   const today = dayjs();
 
   // TODO: 추후 일간, 월간 들어갈지 말지 고려 필요
-  // TODO: 로그인하지 않았을 경우에 대한 화면 처리 필요
   const req = {
+    userId: user?.id!,
     startDateTime: today.isoWeekday(-6).startOf('day').toISOString(),
     endDateTime: today.isoWeekday(0).startOf('day').toISOString(),
   };
 
   const { data: books } = useGetBestRecords(req);
-
-  if (!books) return null;
 
   return device === 'mobile' ? (
     <BestCommentaryMobile books={books} />

--- a/src/components/composites/main/bestCommentary/desktop/BestCommentaryDesktop.tsx
+++ b/src/components/composites/main/bestCommentary/desktop/BestCommentaryDesktop.tsx
@@ -16,7 +16,7 @@ const BestCommentaryDesktop = ({ books }: BestCommentaryDesktopProps) => {
       </header>
       <S.BestCommentaryCardWrapper>
         {books?.map((book) => (
-          <BookRecordCard key={book.id} linkToBaseUrl="book" {...book} />
+          <BookRecordCard key={book.id} bookRecord={book} />
         ))}
       </S.BestCommentaryCardWrapper>
     </S.BestCommentarySection>

--- a/src/components/composites/main/bestCommentary/desktop/BestCommentaryDesktop.tsx
+++ b/src/components/composites/main/bestCommentary/desktop/BestCommentaryDesktop.tsx
@@ -5,7 +5,7 @@ import type { GetBestRecordsServerModel } from '@/types';
 import * as S from './BestCommentaryDesktop.styled';
 
 interface BestCommentaryDesktopProps {
-  books: GetBestRecordsServerModel;
+  books: GetBestRecordsServerModel | null;
 }
 
 const BestCommentaryDesktop = ({ books }: BestCommentaryDesktopProps) => {
@@ -15,7 +15,7 @@ const BestCommentaryDesktop = ({ books }: BestCommentaryDesktopProps) => {
         <S.Title>주간 기록 베스트 10!</S.Title>
       </header>
       <S.BestCommentaryCardWrapper>
-        {books.map((book) => (
+        {books?.map((book) => (
           <BookRecordCard key={book.id} linkToBaseUrl="book" {...book} />
         ))}
       </S.BestCommentaryCardWrapper>

--- a/src/components/composites/main/bestCommentary/mobile/BestCommentaryMobile.tsx
+++ b/src/components/composites/main/bestCommentary/mobile/BestCommentaryMobile.tsx
@@ -8,7 +8,7 @@ import type { GetBestRecordsServerModel } from '@/types';
 import * as S from './BestCommentaryMobile.styled';
 
 interface BestCommentaryMobileProps {
-  books: GetBestRecordsServerModel;
+  books: GetBestRecordsServerModel | null;
 }
 
 const BestCommentaryMobile = ({ books }: BestCommentaryMobileProps) => {
@@ -19,7 +19,6 @@ const BestCommentaryMobile = ({ books }: BestCommentaryMobileProps) => {
         여백과 달라지는 이슈 수정 필요! */}
         <S.Title>주간 기록 베스트 10!</S.Title>
       </header>
-
       <Swiper
         css={S.swiper}
         centeredSlides
@@ -28,7 +27,7 @@ const BestCommentaryMobile = ({ books }: BestCommentaryMobileProps) => {
         slidesPerView={1.2}
         spaceBetween={28}
       >
-        {books.map((book) => (
+        {books?.map((book) => (
           <SwiperSlide key={book.id}>
             <BookRecordCard linkToBaseUrl="book" {...book} />
           </SwiperSlide>

--- a/src/components/composites/main/bestCommentary/mobile/BestCommentaryMobile.tsx
+++ b/src/components/composites/main/bestCommentary/mobile/BestCommentaryMobile.tsx
@@ -29,7 +29,7 @@ const BestCommentaryMobile = ({ books }: BestCommentaryMobileProps) => {
       >
         {books?.map((book) => (
           <SwiperSlide key={book.id}>
-            <BookRecordCard linkToBaseUrl="book" {...book} />
+            <BookRecordCard bookRecord={book} />
           </SwiperSlide>
         ))}
       </Swiper>

--- a/src/components/composites/main/readingBook/ReadingBook.tsx
+++ b/src/components/composites/main/readingBook/ReadingBook.tsx
@@ -1,71 +1,24 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
 
+import { useUser } from '@/contexts';
+import { useGetMyLibraries } from '@/services';
 import { deviceState } from '@/stores';
-import Book1Img from '@/assets/image/book1.png';
-import Book2Img from '@/assets/image/book2.png';
-import type { ReadingBookCardType } from '@/types';
 import ReadingBookMobile from './mobile/ReadingBookMobile';
 import ReadingBookDesktop from './desktop/ReadingBookDesktop';
 
 const ReadingBook = () => {
   const device = useRecoilValue(deviceState);
-  const readingBooks: ReadingBookCardType[] = [
-    {
-      id: '1',
-      bookImgSrc: Book1Img,
-      title:
-        '트렌드코리아 2024 트렌드코리아 2024 트렌드코리아 2024 트렌드코리아 2024 트렌드코리아 2024',
-      publisher: '길벗 출판사',
-      authors: ['홍길동'],
-      readingStartDate: '2024. 02. 17',
-    },
-    {
-      id: '2',
-      bookImgSrc: Book2Img,
-      title: '트렌드코리아 2024',
-      publisher: '길벗 출판사',
-      authors: ['홍길동'],
-      readingStartDate: '2024. 02. 17',
-    },
-    {
-      id: '3',
-      bookImgSrc: Book1Img,
-      title: '트렌드코리아 2024',
-      publisher: '길벗 출판사',
-      authors: ['홍길동', '이준정'],
-      readingStartDate: '2024. 02. 17',
-    },
-    {
-      id: '4',
-      bookImgSrc: Book1Img,
-      title: '트렌드코리아 2024',
-      publisher: '길벗 출판사',
-      authors: ['홍길동'],
-      readingStartDate: '2024. 02. 17',
-    },
-    {
-      id: '5',
-      bookImgSrc: Book2Img,
-      title: '트렌드코리아 2024',
-      publisher: '길벗 출판사',
-      authors: ['홍길동'],
-      readingStartDate: '2024. 02. 17',
-    },
-    {
-      id: '6',
-      bookImgSrc: Book1Img,
-      title: '트렌드코리아 2024 트렌드코리아 2024 트렌드코리아 2024',
-      publisher: '길벗 출판사',
-      authors: ['홍길동'],
-      readingStartDate: '2024. 02. 17',
-    },
-  ];
+
+  const { user } = useUser();
+  const req = { userId: user?.id!, filter: 'ongoing' as const };
+
+  const { data } = useGetMyLibraries(req);
 
   return device === 'mobile' ? (
-    <ReadingBookMobile books={readingBooks} />
+    <ReadingBookMobile books={data?.records} />
   ) : (
-    <ReadingBookDesktop books={readingBooks} />
+    <ReadingBookDesktop books={data?.records} />
   );
 };
 

--- a/src/components/composites/main/readingBook/desktop/ReadingBookDesktop.skeleton.tsx
+++ b/src/components/composites/main/readingBook/desktop/ReadingBookDesktop.skeleton.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { BookReadingCardSkeleton } from '@/components';
+import * as S from './ReadingBookDesktop.styled';
+
+const ReadingBookDesktopSkeleton = () => {
+  return (
+    <S.ReadingBookSection>
+      <header>
+        <S.Title>현재 읽고 있는 책!</S.Title>
+      </header>
+      <S.BookReadingCardWrapper>
+        {Array.from({ length: 3 }, (_, i) => (
+          <BookReadingCardSkeleton key={i} css={S.card} />
+        ))}
+      </S.BookReadingCardWrapper>
+    </S.ReadingBookSection>
+  );
+};
+
+export default ReadingBookDesktopSkeleton;

--- a/src/components/composites/main/readingBook/desktop/ReadingBookDesktop.tsx
+++ b/src/components/composites/main/readingBook/desktop/ReadingBookDesktop.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import { BookAddLink, BookReadingCard } from '@/components';
-import type { ReadingBookCardType } from '@/types';
+import type { GetMyLibraryServerModel } from '@/types';
 import * as S from './ReadingBookDesktop.styled';
 
 interface ReadingBookDesktopProps {
-  books: ReadingBookCardType[];
+  books?: GetMyLibraryServerModel['records'];
 }
 
 const ReadingBookDesktop = ({ books }: ReadingBookDesktopProps) => {
@@ -14,7 +14,7 @@ const ReadingBookDesktop = ({ books }: ReadingBookDesktopProps) => {
       <header>
         <S.Title>현재 읽고 있는 책!</S.Title>
       </header>
-      {books.length ? (
+      {books?.length ? (
         <S.BookReadingCardWrapper>
           {books.map((book) => (
             <BookReadingCard css={S.card} key={book.id} {...book} />

--- a/src/components/composites/main/readingBook/index.ts
+++ b/src/components/composites/main/readingBook/index.ts
@@ -1,1 +1,3 @@
 export { default as ReadingBook } from './ReadingBook';
+export { default as ReadingBookDesktopSkeleton } from './desktop/ReadingBookDesktop.skeleton';
+export { default as ReadingBookMobileSkeleton } from './mobile/ReadingBookMobile.skeleton';

--- a/src/components/composites/main/readingBook/mobile/ReadingBookMobile.skeleton.tsx
+++ b/src/components/composites/main/readingBook/mobile/ReadingBookMobile.skeleton.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { BookReadingCardSkeleton } from '@/components';
+import * as S from './ReadingBookMobile.styled';
+
+const ReadingBookMobileSkeleton = () => {
+  return (
+    <S.ReadingBookSection>
+      <header>
+        <S.Title>현재 읽고 있는 책!</S.Title>
+      </header>
+      <S.SkeletonCardWrapper>
+        {Array.from({ length: 3 }, (_, i) => (
+          <BookReadingCardSkeleton key={i} />
+        ))}
+      </S.SkeletonCardWrapper>
+    </S.ReadingBookSection>
+  );
+};
+
+export default ReadingBookMobileSkeleton;

--- a/src/components/composites/main/readingBook/mobile/ReadingBookMobile.styled.ts
+++ b/src/components/composites/main/readingBook/mobile/ReadingBookMobile.styled.ts
@@ -1,7 +1,15 @@
-import tw from 'twin.macro';
+import tw, { styled } from 'twin.macro';
 
 export const ReadingBookSection = tw.section`mb-[64px]`;
 
 export const Title = tw.h2`mb-[8px] px-[24px] m-body-m15`;
 
 export const swiper = tw`pb-[10px]`;
+
+export const SkeletonCardWrapper = styled.div`
+  ${tw`flex`}
+
+  & > * {
+    ${tw`mx-[24px]`}
+  }
+`;

--- a/src/components/composites/main/readingBook/mobile/ReadingBookMobile.tsx
+++ b/src/components/composites/main/readingBook/mobile/ReadingBookMobile.tsx
@@ -4,11 +4,11 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 import 'swiper/css';
 
 import { BookAddLink, BookReadingCard } from '@/components';
-import type { ReadingBookCardType } from '@/types';
+import type { GetMyLibraryServerModel } from '@/types';
 import * as S from './ReadingBookMobile.styled';
 
 interface ReadingBookMobileProps {
-  books: ReadingBookCardType[];
+  books?: GetMyLibraryServerModel['records'];
 }
 
 const ReadingBookMobile = ({ books }: ReadingBookMobileProps) => {
@@ -17,7 +17,7 @@ const ReadingBookMobile = ({ books }: ReadingBookMobileProps) => {
       <header>
         <S.Title>현재 읽고 있는 책!</S.Title>
       </header>
-      {books.length ? (
+      {books?.length ? (
         <Swiper
           css={S.swiper}
           breakpoints={{

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { Session, User } from '@supabase/supabase-js';
 
 import { supabase } from '@/lib';
+import { queryClient } from '@/services';
 
 export const AuthContext = createContext<{
   isInitializing: boolean;
@@ -31,6 +32,10 @@ export const AuthContextProvider = (props: any) => {
         setUserSession(session);
         setUser(session?.user ?? null);
         setIsInitializing(false);
+
+        if (!session?.user) {
+          queryClient.invalidateQueries();
+        }
       },
     );
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,7 +30,8 @@ const root = () => {
       >
         <ReadingBook />
       </Suspense>
-      <PopularBook />
+      {/* TODO: 추후 기능 도입 예정 */}
+      {/* <PopularBook /> */}
       <Suspense
         fallback={
           device === 'mobile' ? (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,8 @@ import {
   PopularBook,
   BestCommentaryMobileSkeleton,
   BestCommentaryDesktopSkeleton,
+  ReadingBookMobileSkeleton,
+  ReadingBookDesktopSkeleton,
 } from '@/components';
 import { deviceState } from '@/stores';
 import * as S from './index.styled';
@@ -17,7 +19,17 @@ const root = () => {
 
   return (
     <MainLayout css={S.mainLayout}>
-      <ReadingBook />
+      <Suspense
+        fallback={
+          device === 'mobile' ? (
+            <ReadingBookMobileSkeleton />
+          ) : (
+            <ReadingBookDesktopSkeleton />
+          )
+        }
+      >
+        <ReadingBook />
+      </Suspense>
       <PopularBook />
       <Suspense
         fallback={

--- a/src/services/myLibrary.ts
+++ b/src/services/myLibrary.ts
@@ -12,6 +12,6 @@ const myLibrary = {
 export const useGetMyLibraries = (req: GetMyLibraryQueryModel) => {
   return useSuspenseQuery({
     queryKey: myLibrary.list(req),
-    queryFn: () => getMyLibrariesAPI(req),
+    queryFn: () => (req.userId ? getMyLibrariesAPI(req) : null),
   });
 };

--- a/src/services/record.ts
+++ b/src/services/record.ts
@@ -232,6 +232,6 @@ export const useDeleteLikeForRecord = () => {
 export const useGetBestRecords = (req: GetBestRecordsQueryModel) => {
   return useSuspenseQuery({
     queryKey: bookRecordKeys.bestRecord(req),
-    queryFn: () => getBestRecordsAPI(req),
+    queryFn: () => (req.userId ? getBestRecordsAPI(req) : null),
   });
 };

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -1,12 +1,3 @@
-export interface ReadingBookCardType {
-  id: string;
-  bookImgSrc: string;
-  title: string;
-  publisher: string;
-  authors: string[];
-  readingStartDate: string;
-}
-
 export interface PopularBookCardType {
   id: string;
   bookImgSrc: string;

--- a/src/types/myLibrary.ts
+++ b/src/types/myLibrary.ts
@@ -3,8 +3,8 @@ import type { BookRecordServerData } from './record';
 
 export interface GetMyLibraryQueryModel {
   userId: string;
-  page: number;
-  pageSize: number;
+  page?: number;
+  pageSize?: number;
   filter: 'all' | 'ongoing' | 'completed';
 }
 

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -75,19 +75,22 @@ export interface DeleteLikeForRecordQueryModel {
 export interface GetBestRecordsQueryModel {
   startDateTime: string;
   endDateTime: string;
+  userId: string;
 }
 
 export type GetBestRecordsServerModel = {
   created_at: string;
   updated_at: string;
   id: string;
+  user_id: string;
   isbn: string;
   rating: number;
   reading_start_at: string;
   reading_end_at: string;
   record_comment: string;
-  like_count: number;
   thumbnail: string;
   nickname: string;
   profile_url: string | null;
+  like_count: number; // TODO: 추후 삭제 필요
+  isliked: boolean; // TODO: 추후 삭제 필요
 }[];


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature -> main

### 변경 사항
1. 기능 추가/수정
   a. 메인 화면 內 현재 읽고 있는 책 조회 기능 구현
   b. 책 추가 링크 카드 內 내용 및 링크주소(기존: `/addBook`, 수정: `/book`) 변경
   c. 로그아웃 시 react-query 캐시 무효화 처리
       (**<ins>`clear`, `reset` 사용했는데도 정상동작 하지 않아 `invalidateQueries` 사용 -> 확인 필요</ins>**)
   d. 주간 베스트 감상문 카드 클릭 시 기존 링크 형태에서 모달 노출되도록 변경 
    
 


2. 스크린 추가
   a. 현재 읽고 있는 책 스켈레톤 UI 제작
   b. <ins>1-d</ins> 관련, 모달 스크린 제작

3. 기타 수정
   a. 좋아요 버튼 컴포넌트로 분리 후 적용
   b. 주간 베스트 감상문 조회 시 좋아요 여부 반환 추가 관련 수정 (**<ins>추후 검토 후 삭제 필요</ins>**)


### 참고 사항
- **<ins>로그인하지 않았을 때 메인화면 어떻게 보여주어야 할지 논의 필요!</ins>**
